### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,8 @@ With an instance of Decidable, Alt, Divide, or Apply for a given typeclass,
 provides an instance for the corresponding Coproduct, or Product respectively.
 
 ```scala
-scala> import andxor.{AndXorF3, AndXor3}
-import andxor.{AndXorF3, AndXor3}
-
-scala> import andxor.Decidable
-import andxor.Decidable
+scala> import andxor.{AndXorF3, AndXor3, Decidable, Inj}
+import andxor.{AndXorF3, AndXor3, Decidable, Inj}
 
 scala> import scalaz.std.anyVal._
 import scalaz.std.anyVal._
@@ -43,13 +40,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@39602f8f
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@2f4dc0f5
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@7838b5e9
+ds: andxor.Decidable[scalaz.Show] = $anon$1@68f4c415
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -62,10 +59,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@54853dd0
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@2e171711
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@735b2356
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@43b364d6
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -74,7 +71,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@72d0b3a4
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@40c3b391
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -84,13 +81,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@66ba0bb4
+l2o: List ~> Option = $anon$1@2fde1897
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@50656334
+o2l: Option ~> List = $anon$1@3d2bfb23
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))
@@ -121,4 +118,11 @@ res14: Option[Int] = Some(1)
 scala> // convert a Prod to a List[Cop]
      | SISL.toListP((List("foo"), List(1), List(List("bar"))))
 res16: List[SISL.Cop] = List(-\/(List(foo)), \/-(-\/(List(1))), \/-(\/-(List(List(bar)))))
+
+scala> // inject into applicative
+     | Inj.inject[List[SISO.Cop], Option[String]](Some("foo"))
+res18: List[SISO.Cop] = List(-\/(Some(foo)))
+
+scala> Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
+res19: Option[SISO.Cop] = Some(\/-(-\/(Some(1))))
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ With an instance of Decidable, Alt, Divide, or Apply for a given typeclass,
 provides an instance for the corresponding Coproduct, or Product respectively.
 
 ```scala
-scala> import andxor.{AndXorF3, AndXor3, Decidable, Inj}
-import andxor.{AndXorF3, AndXor3, Decidable, Inj}
+scala> import andxor.{AndXorF3, AndXor3, Decidable}
+import andxor.{AndXorF3, AndXor3, Decidable}
 
 scala> import scalaz.std.anyVal._
 import scalaz.std.anyVal._
@@ -40,13 +40,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@14fb8261
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@788fcc75
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@2e9d5b29
+ds: andxor.Decidable[scalaz.Show] = $anon$1@2a5de5bd
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -59,10 +59,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@b9206cd
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$8@6f7a8ba3
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@465cabf9
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@1ff73fad
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -71,7 +71,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@1d553686
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@1d62c2b
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -81,13 +81,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@671cb962
+l2o: List ~> Option = $anon$1@308479c5
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@3f6375cd
+o2l: Option ~> List = $anon$1@2b4dabd9
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))
@@ -114,22 +114,4 @@ res13: Option[String] = Some(foo)
 
 scala> SISO.extractP[Option[Int]](SISO.lift(Option(1)))
 res14: Option[Int] = Some(1)
-
-scala> // convert a Prod to a List[Cop]
-     | SISL.toListP((List("foo"), List(1), List(List("bar"))))
-res16: List[SISL.Cop] = List(-\/(List(foo)), \/-(-\/(List(1))), \/-(\/-(List(List(bar)))))
-
-scala> // inject into applicative
-     | Inj.inject[List[SISO.Cop], Option[String]](Some("foo"))
-res18: List[SISO.Cop] = List(-\/(Some(foo)))
-
-scala> Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
-res19: Option[SISO.Cop] = Some(\/-(-\/(Some(1))))
-
-scala> // inject F[A] into F[B] given a Functor[F]
-     | Inj.inject[List[SISO.Cop], List[Option[String]]](List(Some("foo")))
-res21: List[SISO.Cop] = List(-\/(Some(foo)))
-
-scala> Inj.inject[Option[SISO.Cop], Option[Option[Int]]](None)
-res22: Option[SISO.Cop] = None
 ```

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@21ff0327
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@476ca9a4
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@5df10354
+ds: andxor.Decidable[scalaz.Show] = $anon$1@28103388
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -62,10 +62,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@5aee0a43
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@4d889f34
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@606075e2
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@2f844ea
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -74,7 +74,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@67dabee9
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@128c7ff5
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -84,13 +84,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@6afb6d6b
+l2o: List ~> Option = $anon$1@4af32615
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@730be7b8
+o2l: Option ~> List = $anon$1@4171bd54
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))
@@ -104,4 +104,17 @@ res8: Option[Int] \/ (Option[String] \/ Option[List[String]]) = \/-(-\/(Some(2!)
 
 scala> SISO.lift(Option("foo")).map2(_.map(_.toString ++ "!")).map1(_.map(_.length))
 res9: (Option[Int], Option[String], Option[List[String]]) = (Some(3),None,None)
+
+scala> // extract specific type from Cop or Prod
+     | SISO.extractC[Option[String]](SISO.inj(Option("foo")))
+res11: Option[Option[String]] = Some(Some(foo))
+
+scala> SISO.extractC[Option[Int]](SISO.inj(Option("foo")))
+res12: Option[Option[Int]] = None
+
+scala> SISO.extractP[Option[String]](SISO.lift(Option("foo")))
+res13: Option[String] = Some(foo)
+
+scala> SISO.extractP[Option[Int]](SISO.lift(Option(1)))
+res14: Option[Int] = Some(1)
 ```

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@476ca9a4
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@39602f8f
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@28103388
+ds: andxor.Decidable[scalaz.Show] = $anon$1@7838b5e9
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -62,10 +62,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@4d889f34
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@54853dd0
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@2f844ea
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@735b2356
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -74,7 +74,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@128c7ff5
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@72d0b3a4
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -84,13 +84,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@4af32615
+l2o: List ~> Option = $anon$1@66ba0bb4
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@4171bd54
+o2l: Option ~> List = $anon$1@50656334
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))
@@ -117,4 +117,8 @@ res13: Option[String] = Some(foo)
 
 scala> SISO.extractP[Option[Int]](SISO.lift(Option(1)))
 res14: Option[Int] = Some(1)
+
+scala> // convert a Prod to a List[Cop]
+     | SISL.toListP((List("foo"), List(1), List(List("bar"))))
+res16: List[SISL.Cop] = List(-\/(List(foo)), \/-(-\/(List(1))), \/-(\/-(List(List(bar)))))
 ```

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@544036bd
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@14fb8261
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@3e799ebf
+ds: andxor.Decidable[scalaz.Show] = $anon$1@2e9d5b29
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -59,10 +59,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@1c7a3362
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@b9206cd
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@7b0bdb11
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@465cabf9
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -71,7 +71,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@7e387b70
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@1d553686
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -81,13 +81,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@4bf71e61
+l2o: List ~> Option = $anon$1@671cb962
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@6344b561
+o2l: Option ~> List = $anon$1@3f6375cd
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))
@@ -125,4 +125,11 @@ res18: List[SISO.Cop] = List(-\/(Some(foo)))
 
 scala> Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
 res19: Option[SISO.Cop] = Some(\/-(-\/(Some(1))))
+
+scala> // inject F[A] into F[B] given a Functor[F]
+     | Inj.inject[List[SISO.Cop], List[Option[String]]](List(Some("foo")))
+res21: List[SISO.Cop] = List(-\/(Some(foo)))
+
+scala> Inj.inject[Option[SISO.Cop], Option[Option[Int]]](None)
+res22: Option[SISO.Cop] = None
 ```

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ scala> import scalaz.{Show, \/, ~>}
 import scalaz.{Show, $bslash$div, $tilde$greater}
 
 scala> val SIS = AndXor3[String, Int, List[String]]
-SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@2f4dc0f5
+SIS: andxor.AndXor3[String,Int,List[String]] = andxor.AndXor3$$anon$1@544036bd
 
 scala> import SIS.instances._ // for inject instances
 import SIS.instances._
 
 scala> implicit val ds: Decidable[Show] = new Decidable[Show] { def choose2[Z, A1, A2](a1: => Show[A1], a2: =>Show[A2])(f: Z => (A1 \/ A2)): Show[Z] = Show.show[Z]((z: Z) => f(z).fold(a1.show(_), a2.show(_))) }
-ds: andxor.Decidable[scalaz.Show] = $anon$1@68f4c415
+ds: andxor.Decidable[scalaz.Show] = $anon$1@3e799ebf
 
 scala> SIS.combine[Show].choose.show(SIS.inj("foo"))
 res0: scalaz.Cord = "foo"
@@ -59,10 +59,10 @@ res2: scalaz.Cord = ["bar","baz"]
 
 scala> // lift into monoidal product
      | val SISF = AndXorF3[String, Int, List[String]]
-SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@2e171711
+SISF: andxor.AndXorF3[String,Int,List[String]] = andxor.AndXorF3$$anon$5@1c7a3362
 
 scala> val SISL = SISF[List]
-SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@43b364d6
+SISL: SISF.Repr[List] = andxor.AndXorF3$$anon$3@7b0bdb11
 
 scala> import SISL.instances._ // for inject instances
 import SISL.instances._
@@ -71,7 +71,7 @@ scala> val ls = SISL.lift(List(4)) |+| SISL.lift(List("foo")) |+| SISL.lift(List
 ls: SISL.Prod = (List(foo),List(4),List(List(bar)))
 
 scala> val SISO = SISF[Option]
-SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@40c3b391
+SISO: SISF.Repr[Option] = andxor.AndXorF3$$anon$3@7e387b70
 
 scala> import SISO.instances._ // for inject instances
 import SISO.instances._
@@ -81,13 +81,13 @@ os: SISO.Prod = (Some(foo),Some(4),Some(List(bar)))
 
 scala> // convert between F[_]s using a ~>
      | val l2o = new (List ~> Option) { def apply[A](l: List[A]): Option[A] = l.headOption }
-l2o: List ~> Option = $anon$1@2fde1897
+l2o: List ~> Option = $anon$1@4bf71e61
 
 scala> SISL.transformP(l2o)(ls)
 res5: (Option[String], Option[Int], Option[List[String]]) = (Some(foo),Some(4),Some(List(bar)))
 
 scala> val o2l = new (Option ~> List) { def apply[A](o: Option[A]): List[A] = o.toList }
-o2l: Option ~> List = $anon$1@3d2bfb23
+o2l: Option ~> List = $anon$1@6344b561
 
 scala> SISO.transformP(o2l)(os)
 res6: (List[String], List[Int], List[List[String]]) = (List(foo),List(4),List(List(bar)))

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 lazy val generate = (project in file("./generate")).
   settings(
     organization := "andxor",
-    scalaVersion := "2.12.5",
+    scalaVersion := "2.12.7",
     libraryDependencies ++= Seq(
-      "org.scalaz" %% "scalaz-core" % "7.2.17",
+      "org.scalaz" %% "scalaz-core" % "7.2.26",
       "com.github.pathikrit" %% "better-files" % "3.5.0",
       "com.geirsson" %% "scalafmt-core" % "1.6.0-RC1"),
     scalacOptions ++= Seq(
@@ -33,9 +33,9 @@ lazy val generate = (project in file("./generate")).
 lazy val core = (project in file("./core")).
   settings(
     organization := "andxor",
-    scalaVersion := "2.12.5",
+    scalaVersion := "2.12.7",
     libraryDependencies ++= Seq(
-      "org.scalaz" %% "scalaz-core" % "7.2.17"),
+      "org.scalaz" %% "scalaz-core" % "7.2.26"),
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding", "UTF-8", // yes, this is 2 args

--- a/core/src/main/scala/andxor/AndXor10.scala
+++ b/core/src/main/scala/andxor/AndXor10.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10])
@@ -27,7 +26,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -81,7 +80,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ F[A10]))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -90,7 +89,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ F[A10])].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -99,7 +98,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[F[A10]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -108,7 +107,7 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor10.scala
+++ b/core/src/main/scala/andxor/AndXor10.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
@@ -25,125 +23,195 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
   }
 
@@ -179,8 +247,6 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor10.scala
+++ b/core/src/main/scala/andxor/AndXor10.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -114,85 +116,35 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
         case _                                              => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
-
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor10.scala
+++ b/core/src/main/scala/andxor/AndXor10.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
@@ -26,32 +27,92 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10]))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ F[A10])))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ F[A10]))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ F[A10])].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[F[A10]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))) => Some(x)
+        case _                                              => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8) =
@@ -59,11 +120,15 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8) =
@@ -71,11 +136,15 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8) =
@@ -83,11 +152,15 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8) =
@@ -95,11 +168,15 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8) =
@@ -107,11 +184,15 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _))
     }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
   }
 
@@ -143,6 +224,10 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9)).curried))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor10.scala
+++ b/core/src/main/scala/andxor/AndXor10.scala
@@ -229,6 +229,8 @@ trait AndXorK10[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK10[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor11.scala
+++ b/core/src/main/scala/andxor/AndXor11.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -124,93 +126,38 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
         case _                                                   => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor11.scala
+++ b/core/src/main/scala/andxor/AndXor11.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndXor {
@@ -27,35 +28,101 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ (F[A10] \/ F[A11]))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[(F[A10] \/ F[A11])].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.left[F[A11]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
+
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(_.right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
@@ -63,11 +130,15 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9) =
@@ -75,11 +146,15 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9) =
@@ -87,11 +162,15 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9) =
@@ -99,11 +178,15 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9) =
@@ -111,17 +194,23 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
   }
 
@@ -154,6 +243,10 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10)).curried)))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor11.scala
+++ b/core/src/main/scala/andxor/AndXor11.scala
@@ -248,6 +248,8 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK11[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor11.scala
+++ b/core/src/main/scala/andxor/AndXor11.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndXor {
@@ -26,137 +24,214 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
   }
 
@@ -193,8 +268,6 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor11.scala
+++ b/core/src/main/scala/andxor/AndXor11.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11])
@@ -28,7 +27,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -37,7 +36,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -46,7 +45,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -55,7 +54,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -64,7 +63,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -73,7 +72,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11]))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -82,7 +81,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ F[A11])))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -91,7 +90,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ (F[A10] \/ F[A11]))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -100,7 +99,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[(F[A10] \/ F[A11])].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -109,7 +108,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.left[F[A11]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -118,7 +117,7 @@ trait AndXorK11[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11] extends AndX
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(_.right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor12.scala
+++ b/core/src/main/scala/andxor/AndXor12.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12])
@@ -40,7 +39,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -49,7 +48,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -58,7 +57,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -67,7 +66,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -76,7 +75,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -85,7 +84,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -94,7 +93,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -103,7 +102,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -112,7 +111,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[(F[A10] \/ (F[A11] \/ F[A12]))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -121,7 +120,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.left[(F[A11] \/ F[A12])].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -130,7 +129,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(_.left[F[A12]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -139,7 +138,7 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(_.right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor12.scala
+++ b/core/src/main/scala/andxor/AndXor12.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends AndXor {
@@ -39,38 +40,110 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12]))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ F[A12])))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[(F[A10] \/ (F[A11] \/ F[A12]))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.left[(F[A11] \/ F[A12])].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(_.left[F[A12]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(_.right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
@@ -78,11 +151,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
@@ -90,11 +167,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10) =
@@ -102,11 +183,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10) =
@@ -114,11 +199,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10) =
@@ -126,11 +215,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10))
     }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10) =
@@ -138,11 +231,15 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10))
     }
 
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _))
     }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
 
   }
 
@@ -180,6 +277,10 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11)).curried))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor12.scala
+++ b/core/src/main/scala/andxor/AndXor12.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -145,101 +147,41 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
         case _                                                        => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor12.scala
+++ b/core/src/main/scala/andxor/AndXor12.scala
@@ -282,6 +282,8 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK12[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor12.scala
+++ b/core/src/main/scala/andxor/AndXor12.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends AndXor {
@@ -38,149 +36,233 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
 
   }
 
@@ -222,8 +304,6 @@ trait AndXorK12[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12] extends
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor13.scala
+++ b/core/src/main/scala/andxor/AndXor13.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] extends AndXor {
@@ -40,41 +41,119 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.left[(F[A11] \/ (F[A12] \/ F[A13]))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(_.left[(F[A12] \/ F[A13])].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(_.left[F[A13]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
+
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(_.right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
@@ -82,11 +161,15 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
@@ -94,11 +177,15 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11) =
@@ -106,11 +193,15 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11) =
@@ -118,11 +209,15 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11) =
@@ -130,11 +225,15 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11))
     }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11) =
@@ -142,17 +241,23 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11))
     }
 
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
   }
 
@@ -194,6 +299,10 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12)).curried)))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor13.scala
+++ b/core/src/main/scala/andxor/AndXor13.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13])
@@ -41,7 +40,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -50,7 +49,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -59,7 +58,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -68,7 +67,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -77,7 +76,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -86,7 +85,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -95,7 +94,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -104,7 +103,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13]))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -113,7 +112,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ F[A13])))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -122,7 +121,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.left[(F[A11] \/ (F[A12] \/ F[A13]))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -131,7 +130,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(_.left[(F[A12] \/ F[A13])].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -140,7 +139,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(_.left[F[A13]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -149,7 +148,7 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(_.right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor13.scala
+++ b/core/src/main/scala/andxor/AndXor13.scala
@@ -304,6 +304,8 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK13[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor13.scala
+++ b/core/src/main/scala/andxor/AndXor13.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -155,109 +157,44 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
         case _                                                             => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor13.scala
+++ b/core/src/main/scala/andxor/AndXor13.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] extends AndXor {
@@ -39,161 +37,252 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
   }
 
@@ -239,8 +328,6 @@ trait AndXorK13[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13] ex
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor14.scala
+++ b/core/src/main/scala/andxor/AndXor14.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14] extends AndXor {
@@ -43,44 +44,128 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(_.left[(F[A12] \/ (F[A13] \/ F[A14]))].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(_.left[(F[A13] \/ F[A14])].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(_.left[F[A14]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(_.right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
@@ -88,11 +173,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
@@ -100,11 +189,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
@@ -112,11 +205,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12) =
@@ -124,11 +221,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12) =
@@ -136,11 +237,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12))
     }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12) =
@@ -148,11 +253,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12))
     }
 
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12))
     }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
 
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12) =
@@ -160,11 +269,15 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12))
     }
 
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _))
     }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
 
   }
 
@@ -210,6 +323,10 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13)).curried))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor14.scala
+++ b/core/src/main/scala/andxor/AndXor14.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -167,117 +169,47 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                  => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor14.scala
+++ b/core/src/main/scala/andxor/AndXor14.scala
@@ -328,6 +328,8 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK14[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor14.scala
+++ b/core/src/main/scala/andxor/AndXor14.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14] extends AndXor {
@@ -42,173 +40,271 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
 
   }
 
@@ -258,8 +354,6 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor14.scala
+++ b/core/src/main/scala/andxor/AndXor14.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14])
@@ -44,7 +43,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -53,7 +52,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -62,7 +61,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -71,7 +70,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -80,7 +79,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -89,7 +88,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -98,7 +97,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -107,7 +106,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -116,7 +115,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14]))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -125,7 +124,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ F[A14])))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -134,7 +133,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(_.left[(F[A12] \/ (F[A13] \/ F[A14]))].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -143,7 +142,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(_.left[(F[A13] \/ F[A14])].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -152,7 +151,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(_.left[F[A14]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -161,7 +160,7 @@ trait AndXorK14[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(_.right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor15.scala
+++ b/core/src/main/scala/andxor/AndXor15.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15] extends AndXor {
@@ -43,185 +41,290 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
   }
 
@@ -279,8 +382,6 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor15.scala
+++ b/core/src/main/scala/andxor/AndXor15.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15] extends AndXor {
@@ -44,57 +45,147 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(_.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
         _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
         _.left[(F[A13] \/ (F[A14] \/ F[A15]))].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
         _.left[(F[A14] \/ F[A15])].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
         _.left[F[A15]].right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
+
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
         _.right[F[A14]].right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
@@ -102,11 +193,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
@@ -114,11 +209,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
@@ -126,11 +225,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13) =
@@ -138,11 +241,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13) =
@@ -150,11 +257,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13))
     }
 
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13))
     }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13) =
@@ -162,11 +273,15 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13))
     }
 
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13))
     }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
 
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13) =
@@ -174,17 +289,23 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13))
     }
 
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
   }
 
@@ -238,6 +359,10 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14)).curried)))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor15.scala
+++ b/core/src/main/scala/andxor/AndXor15.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -187,125 +189,50 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                       => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor15.scala
+++ b/core/src/main/scala/andxor/AndXor15.scala
@@ -364,6 +364,8 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK15[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor15.scala
+++ b/core/src/main/scala/andxor/AndXor15.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15])
@@ -45,7 +44,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -81,7 +80,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -90,7 +89,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -99,7 +98,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -108,7 +107,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -117,7 +116,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -126,7 +125,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(_.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15]))))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -135,9 +134,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ F[A15])))].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -146,9 +143,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ F[A15]))].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -157,9 +152,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ F[A15])].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -168,9 +161,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[F[A15]].right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -179,9 +170,7 @@ trait AndXorK15[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.right[F[A14]].right[F[A13]].right[F[A12]].right[F[A11]].right[F[A10]].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor16.scala
+++ b/core/src/main/scala/andxor/AndXor16.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -285,133 +287,53 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                            => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor16.scala
+++ b/core/src/main/scala/andxor/AndXor16.scala
@@ -474,6 +474,8 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK16[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor16.scala
+++ b/core/src/main/scala/andxor/AndXor16.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16])
@@ -46,7 +45,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -55,7 +54,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -64,7 +63,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -73,7 +72,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -82,9 +81,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -93,9 +90,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -104,9 +99,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -115,9 +108,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -126,9 +117,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -137,9 +126,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -148,19 +135,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -169,20 +144,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -191,21 +153,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ F[A16]))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -214,22 +162,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ F[A16])]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -238,23 +171,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[F[A16]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -263,23 +180,7 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor16.scala
+++ b/core/src/main/scala/andxor/AndXor16.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16] extends AndXor {
@@ -44,197 +42,309 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
 
   }
 
@@ -296,8 +406,6 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor16.scala
+++ b/core/src/main/scala/andxor/AndXor16.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16] extends AndXor {
@@ -45,44 +46,104 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
         _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
         _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
         _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))))].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
         _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))))].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
         _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16]))))))].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
         _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))))].right[F[A9]].right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
@@ -99,6 +160,12 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
         _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ F[A16])))]
@@ -114,6 +181,12 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
@@ -132,6 +205,12 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
         _.left[(F[A15] \/ F[A16])]
@@ -149,6 +228,12 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
 
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
@@ -169,6 +254,12 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
+
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
         _.right[F[A15]]
@@ -188,11 +279,19 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
@@ -200,11 +299,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
@@ -212,11 +315,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
@@ -224,11 +331,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14) =
@@ -236,11 +347,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14) =
@@ -248,11 +363,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14) =
@@ -260,11 +379,15 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14) =
@@ -272,17 +395,23 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14))
     }
 
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _))
     }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
 
   }
 
@@ -340,6 +469,10 @@ trait AndXorK16[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15)).curried))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor17.scala
+++ b/core/src/main/scala/andxor/AndXor17.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17] extends AndXor {
@@ -46,209 +44,328 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
   }
 
@@ -314,8 +431,6 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor17.scala
+++ b/core/src/main/scala/andxor/AndXor17.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17] extends AndXor {
@@ -49,20 +50,44 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))))))))]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))))))))].right[F[A1]]
       )
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
         _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))))))].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
         _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
@@ -72,6 +97,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
 
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
@@ -83,6 +114,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
+
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
         _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))]
@@ -93,6 +130,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
 
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
@@ -106,6 +149,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
+
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
         _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))]
@@ -118,6 +167,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
 
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
@@ -133,6 +188,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
+
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
         _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))]
@@ -147,6 +208,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
 
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
@@ -164,6 +231,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
+
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
         _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))]
@@ -180,6 +253,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
 
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
@@ -199,6 +278,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
+
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
         _.left[(F[A16] \/ F[A17])]
@@ -217,6 +302,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
 
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
@@ -238,6 +329,12 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
+
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
         _.right[F[A16]]
@@ -258,11 +355,19 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
@@ -270,11 +375,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
@@ -282,11 +391,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
@@ -294,11 +407,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
@@ -306,11 +423,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15) =
@@ -318,11 +439,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15) =
@@ -330,11 +455,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15) =
@@ -342,11 +471,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15) =
@@ -354,11 +487,15 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _))
     }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
   }
 
@@ -420,6 +557,10 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16)).curried)))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor17.scala
+++ b/core/src/main/scala/andxor/AndXor17.scala
@@ -562,6 +562,8 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK17[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor17.scala
+++ b/core/src/main/scala/andxor/AndXor17.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -361,141 +363,56 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                 => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor17.scala
+++ b/core/src/main/scala/andxor/AndXor17.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17])
@@ -48,9 +47,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))))))))]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -59,9 +56,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))))))))].right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -70,9 +65,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))))))].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -81,9 +74,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -92,13 +83,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))))]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -107,14 +92,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -123,15 +101,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -140,16 +110,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -158,17 +119,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -177,18 +128,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -197,19 +137,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -218,20 +146,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17]))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -240,21 +155,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ F[A17])))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -263,22 +164,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ F[A17]))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -287,23 +173,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ F[A17])]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -312,24 +182,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[F[A17]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -338,24 +191,7 @@ trait AndXorK17[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor18.scala
+++ b/core/src/main/scala/andxor/AndXor18.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18] extends AndXor {
@@ -48,221 +46,347 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    }
 
-    implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma17: Prism[Cop, F[A18]] = new Prism[Cop, F[A18]] {
+      def getOption(c: Cop): Option[F[A18]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A18]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja17: Inj[Cop, F[A18]] = Inj.instance(prisma17.reverseGet(_))
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] = Inj.instance(prisma17.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
-    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
-      IsoSet(_._18, x => M.zero.map18(_ => x))
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
+    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _))
+    }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
 
   }
 
@@ -368,8 +492,6 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor18.scala
+++ b/core/src/main/scala/andxor/AndXor18.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17], F[A18])
@@ -50,11 +49,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[
-          (F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))))))))))))
-        ]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -63,10 +58,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))))))]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -75,11 +67,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))))))))))]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -88,12 +76,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))))]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -102,13 +85,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))))))))]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -117,14 +94,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -133,15 +103,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -150,16 +112,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -168,17 +121,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -187,18 +130,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -207,19 +139,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -228,20 +148,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -250,21 +157,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18]))))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -273,22 +166,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -297,23 +175,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ (F[A17] \/ F[A18]))]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -322,24 +184,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[(F[A17] \/ F[A18])]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -348,25 +193,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.left[F[A18]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {
@@ -375,25 +202,7 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(
-        _.right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))
 
     implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor18.scala
+++ b/core/src/main/scala/andxor/AndXor18.scala
@@ -648,6 +648,8 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK18[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor18.scala
+++ b/core/src/main/scala/andxor/AndXor18.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -399,149 +401,59 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                      => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
-
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
-
-    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _))
-    }
-
-    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
+      IsoSet(_._18, x => M.zero.map18(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor18.scala
+++ b/core/src/main/scala/andxor/AndXor18.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18] extends AndXor {
@@ -53,11 +54,23 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))))))]
           .right[F[A1]]
       )
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
@@ -66,6 +79,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
         _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))))]
@@ -73,6 +92,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
@@ -83,6 +108,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
         _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))))]
@@ -92,6 +123,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
@@ -104,6 +141,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
         _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))))]
@@ -115,6 +158,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
@@ -129,6 +178,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
         _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))))]
@@ -142,6 +197,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
@@ -158,6 +219,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
         _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))))]
@@ -173,6 +240,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
@@ -191,6 +264,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
         _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ F[A18])))]
@@ -208,6 +287,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
 
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
@@ -228,6 +313,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
+
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
         _.left[(F[A17] \/ F[A18])]
@@ -247,6 +338,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
 
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
@@ -269,6 +366,12 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
+
     implicit val inja17: Inj[Cop, F[A18]] =
       Inj.instance(
         _.right[F[A17]]
@@ -290,11 +393,19 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
@@ -302,11 +413,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
@@ -314,11 +429,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
@@ -326,11 +445,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
@@ -338,11 +461,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16) =
@@ -350,11 +477,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16) =
@@ -362,11 +493,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16) =
@@ -374,11 +509,15 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16) =
@@ -386,17 +525,23 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16))
     }
 
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
     implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _))
     }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
 
   }
 
@@ -498,6 +643,10 @@ trait AndXorK18[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17)).curried))))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor19.scala
+++ b/core/src/main/scala/andxor/AndXor19.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -431,157 +433,62 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                           => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
+      IsoSet(_._18, x => M.zero.map18(_ => x))
 
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
-
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
-
-    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17))
-    }
-
-    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
-
-    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _))
-    }
-
-    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
+    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
+      IsoSet(_._19, x => M.zero.map19(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor19.scala
+++ b/core/src/main/scala/andxor/AndXor19.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17], F[A18], F[A19])
@@ -52,11 +51,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[
-          A19
-        ])))))))))))))))))]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -65,11 +60,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[
-          A19
-        ]))))))))))))))))].right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -78,11 +69,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))))))]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -91,12 +78,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))))))))))))]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -105,13 +87,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))))]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -120,14 +96,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -136,15 +105,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -153,16 +114,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -171,17 +123,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -190,18 +132,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -210,19 +141,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -231,20 +150,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -253,21 +159,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -276,22 +168,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19]))))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -300,23 +177,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -325,24 +186,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[(F[A17] \/ (F[A18] \/ F[A19]))]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -351,25 +195,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.left[(F[A18] \/ F[A19])]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {
@@ -378,26 +204,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(
-        _.left[F[A19]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
 
     implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
       Inj.instance(_ match {
@@ -406,26 +213,7 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(
-        _.right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))
 
     implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor19.scala
+++ b/core/src/main/scala/andxor/AndXor19.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19] extends AndXor {
@@ -50,233 +48,366 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    }
 
-    implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma17: Prism[Cop, F[A18]] = new Prism[Cop, F[A18]] {
+      def getOption(c: Cop): Option[F[A18]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
         case _                                                                                           => None
-      })
+      }
+      def reverseGet(x: F[A18]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    }
 
-    implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))
+    implicit val inja17: Inj[Cop, F[A18]] = Inj.instance(prisma17.reverseGet(_))
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] = Inj.instance(prisma17.getOption(_))
 
-    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma18: Prism[Cop, F[A19]] = new Prism[Cop, F[A19]] {
+      def getOption(c: Cop): Option[F[A19]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))) => Some(x)
         case _                                                                                           => None
-      })
+      }
+      def reverseGet(x: F[A19]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja18: Inj[Cop, F[A19]] = Inj.instance(prisma18.reverseGet(_))
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] = Inj.instance(prisma18.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
-    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
-      IsoSet(_._18, x => M.zero.map18(_ => x))
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
 
-    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
-      IsoSet(_._19, x => M.zero.map19(_ => x))
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
+    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17))
+    }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
+    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _))
+    }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
 
   }
 
@@ -408,8 +539,6 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor19.scala
+++ b/core/src/main/scala/andxor/AndXor19.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19] extends AndXor {
@@ -55,6 +56,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ])))))))))))))))))]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[
@@ -62,12 +69,24 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ]))))))))))))))))].right[F[A1]]
       )
 
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
+
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
         _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))))))]
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
 
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
@@ -77,6 +96,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
+
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
         _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))))]
@@ -85,6 +110,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
 
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
@@ -96,6 +127,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
+
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
         _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))))]
@@ -106,6 +143,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
 
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
@@ -119,6 +162,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
+
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
         _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))))]
@@ -131,6 +180,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
 
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
@@ -146,6 +201,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
+
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
         _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))))]
@@ -160,6 +221,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
 
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
@@ -177,6 +244,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
+
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
         _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))))]
@@ -193,6 +266,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
 
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
@@ -212,6 +291,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
+
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
         _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ F[A19])))]
@@ -230,6 +315,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
 
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
@@ -251,6 +342,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
+
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
         _.left[(F[A18] \/ F[A19])]
@@ -271,6 +368,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
 
     implicit val inja17: Inj[Cop, F[A18]] =
       Inj.instance(
@@ -294,6 +397,12 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
+        case _                                                                                           => None
+      })
+
     implicit val inja18: Inj[Cop, F[A19]] =
       Inj.instance(
         _.right[F[A18]]
@@ -316,11 +425,19 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))) => Some(x)
+        case _                                                                                           => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
@@ -328,11 +445,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
@@ -340,11 +461,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
@@ -352,11 +477,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
@@ -364,11 +493,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17) =
@@ -376,11 +509,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17) =
@@ -388,11 +525,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17) =
@@ -400,11 +541,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17) =
@@ -412,11 +557,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17))
     }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
     implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17) =
@@ -424,11 +573,15 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17))
     }
 
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
     implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _))
     }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
 
   }
 
@@ -556,6 +709,10 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18)).curried)))))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor19.scala
+++ b/core/src/main/scala/andxor/AndXor19.scala
@@ -714,6 +714,8 @@ trait AndXorK19[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK19[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor2.scala
+++ b/core/src/main/scala/andxor/AndXor2.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK2[F[_], A1, A2] extends AndXor {
   type Prod = (F[A1], F[A2])
@@ -27,7 +26,7 @@ trait AndXorK2[F[_], A1, A2] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[F[A2]])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK2[F[_], A1, A2] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.right[F[A1]])
+      Inj.instance(x => \/-(x))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor2.scala
+++ b/core/src/main/scala/andxor/AndXor2.scala
@@ -84,6 +84,8 @@ trait AndXorK2[F[_], A1, A2] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK2[Id, A1, A2]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor2.scala
+++ b/core/src/main/scala/andxor/AndXor2.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -42,21 +44,11 @@ trait AndXorK2[F[_], A1, A2] extends AndXor {
         case _      => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0) =
-        M.zero
-      Inj.instance((_, a0))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
-
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _) =
-        M.zero
-      Inj.instance((a0, _))
-    }
-
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor20.scala
+++ b/core/src/main/scala/andxor/AndXor20.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20] extends AndXor {
@@ -51,245 +49,385 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    }
 
-    implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma17: Prism[Cop, F[A18]] = new Prism[Cop, F[A18]] {
+      def getOption(c: Cop): Option[F[A18]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
         case _                                                                                           => None
-      })
+      }
+      def reverseGet(x: F[A18]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    }
 
-    implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
+    implicit val inja17: Inj[Cop, F[A18]] = Inj.instance(prisma17.reverseGet(_))
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] = Inj.instance(prisma17.getOption(_))
 
-    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma18: Prism[Cop, F[A19]] = new Prism[Cop, F[A19]] {
+      def getOption(c: Cop): Option[F[A19]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
         case _                                                                                                => None
-      })
+      }
+      def reverseGet(x: F[A19]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    }
 
-    implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))
+    implicit val inja18: Inj[Cop, F[A19]] = Inj.instance(prisma18.reverseGet(_))
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] = Inj.instance(prisma18.getOption(_))
 
-    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma19: Prism[Cop, F[A20]] = new Prism[Cop, F[A20]] {
+      def getOption(c: Cop): Option[F[A20]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))) => Some(x)
         case _                                                                                                => None
-      })
+      }
+      def reverseGet(x: F[A20]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja19: Inj[Cop, F[A20]] = Inj.instance(prisma19.reverseGet(_))
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] = Inj.instance(prisma19.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
-    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
-      IsoSet(_._18, x => M.zero.map18(_ => x))
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
 
-    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
-      IsoSet(_._19, x => M.zero.map19(_ => x))
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
-    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
-      IsoSet(_._20, x => M.zero.map20(_ => x))
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
+    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18))
+    }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
+    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18))
+    }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
+
+    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _))
+    }
+
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
 
   }
 
@@ -428,8 +566,6 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor20.scala
+++ b/core/src/main/scala/andxor/AndXor20.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17], F[A18], F[A19], F[A20])
@@ -53,11 +52,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[
-          A19
-        ] \/ F[A20]))))))))))))))))))]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -66,11 +61,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[
-          A20
-        ])))))))))))))))))].right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -79,11 +70,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[
-          A20
-        ]))))))))))))))))].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -92,12 +79,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))))))]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -106,13 +88,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))))))))))))]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -121,14 +97,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -137,15 +106,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -154,16 +115,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -172,17 +124,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -191,18 +133,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -211,19 +142,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -232,20 +151,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -254,21 +160,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -277,22 +169,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -301,23 +178,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20]))))]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -326,24 +187,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[(F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -352,25 +196,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.left[(F[A18] \/ (F[A19] \/ F[A20]))]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {
@@ -379,26 +205,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(
-        _.left[(F[A19] \/ F[A20])]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
 
     implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
       Inj.instance(_ match {
@@ -407,27 +214,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(
-        _.left[F[A20]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
 
     implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
       Inj.instance(_ match {
@@ -436,27 +223,7 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(
-        _.right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))
 
     implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor20.scala
+++ b/core/src/main/scala/andxor/AndXor20.scala
@@ -760,6 +760,8 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK20[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor20.scala
+++ b/core/src/main/scala/andxor/AndXor20.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -462,165 +464,65 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                                => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
+      IsoSet(_._18, x => M.zero.map18(_ => x))
 
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
+    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
+      IsoSet(_._19, x => M.zero.map19(_ => x))
 
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
-
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
-
-    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18))
-    }
-
-    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
-
-    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18))
-    }
-
-    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
-
-    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _))
-    }
-
-    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
+    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
+      IsoSet(_._20, x => M.zero.map20(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor20.scala
+++ b/core/src/main/scala/andxor/AndXor20.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20] extends AndXor {
@@ -56,12 +57,24 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ] \/ F[A20]))))))))))))))))))]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[
           A20
         ])))))))))))))))))].right[F[A1]]
       )
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
@@ -70,6 +83,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ]))))))))))))))))].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
         _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))))))]
@@ -77,6 +96,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
@@ -87,6 +112,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
         _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))))]
@@ -96,6 +127,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
@@ -108,6 +145,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
         _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))))]
@@ -119,6 +162,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
@@ -133,6 +182,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
         _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))))]
@@ -146,6 +201,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
@@ -162,6 +223,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
         _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))))]
@@ -177,6 +244,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
@@ -195,6 +268,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
         _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))))]
@@ -212,6 +291,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
 
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
@@ -232,6 +317,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
+
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
         _.left[(F[A17] \/ (F[A18] \/ (F[A19] \/ F[A20])))]
@@ -251,6 +342,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
 
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
@@ -273,6 +370,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
+
     implicit val inja17: Inj[Cop, F[A18]] =
       Inj.instance(
         _.left[(F[A19] \/ F[A20])]
@@ -294,6 +397,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
+        case _                                                                                           => None
+      })
 
     implicit val inja18: Inj[Cop, F[A19]] =
       Inj.instance(
@@ -318,6 +427,12 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
+        case _                                                                                                => None
+      })
+
     implicit val inja19: Inj[Cop, F[A20]] =
       Inj.instance(
         _.right[F[A19]]
@@ -341,11 +456,19 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))) => Some(x)
+        case _                                                                                                => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -353,11 +476,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -365,11 +492,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -377,11 +508,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -389,11 +524,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -401,11 +540,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18) =
@@ -413,11 +556,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18) =
@@ -425,11 +572,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18) =
@@ -437,11 +588,15 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18))
     }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
     implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18) =
@@ -449,17 +604,23 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18))
     }
 
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
     implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18))
     }
 
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
+
     implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _))
     }
+
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
 
   }
 
@@ -594,6 +755,10 @@ trait AndXorK20[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18, i19)).curried))))))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor21.scala
+++ b/core/src/main/scala/andxor/AndXor21.scala
@@ -806,6 +806,8 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK21[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor21.scala
+++ b/core/src/main/scala/andxor/AndXor21.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17], F[A18], F[A19], F[A20], F[A21])
@@ -54,11 +53,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[
-          A19
-        ] \/ (F[A20] \/ F[A21])))))))))))))))))))]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -67,11 +62,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[
-          A20
-        ] \/ F[A21]))))))))))))))))))].right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -80,11 +71,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[
-          A21
-        ])))))))))))))))))].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -93,11 +80,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[
-          A21
-        ]))))))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -106,13 +89,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))))))))]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -121,14 +98,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -137,15 +107,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -154,16 +116,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -172,17 +125,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -191,18 +134,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -211,19 +143,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -232,20 +152,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -254,21 +161,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -277,22 +170,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -301,23 +179,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -326,24 +188,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[(F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21]))))]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -352,25 +197,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.left[(F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {
@@ -379,26 +206,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(
-        _.left[(F[A19] \/ (F[A20] \/ F[A21]))]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
 
     implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
       Inj.instance(_ match {
@@ -407,27 +215,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(
-        _.left[(F[A20] \/ F[A21])]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
 
     implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
       Inj.instance(_ match {
@@ -436,28 +224,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(
-        _.left[F[A21]]
-          .right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))))
 
     implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
       Inj.instance(_ match {
@@ -466,28 +233,7 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja20: Inj[Cop, F[A21]] =
-      Inj.instance(
-        _.right[F[A20]]
-          .right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))))
 
     implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor21.scala
+++ b/core/src/main/scala/andxor/AndXor21.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -493,173 +495,68 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                                     => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
+      IsoSet(_._18, x => M.zero.map18(_ => x))
 
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
+    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
+      IsoSet(_._19, x => M.zero.map19(_ => x))
 
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
+      IsoSet(_._20, x => M.zero.map20(_ => x))
 
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
-
-    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19))
-    }
-
-    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
-
-    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19))
-    }
-
-    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
-
-    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19))
-    }
-
-    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
-
-    implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _))
-    }
-
-    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
+    implicit def liftisoa20(implicit M: Monoid[Prod]): Prod <=> F[A21] =
+      IsoSet(_._21, x => M.zero.map21(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor21.scala
+++ b/core/src/main/scala/andxor/AndXor21.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21] extends AndXor {
@@ -57,12 +58,24 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ] \/ (F[A20] \/ F[A21])))))))))))))))))))]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[
           A20
         ] \/ F[A21]))))))))))))))))))].right[F[A1]]
       )
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
@@ -71,12 +84,24 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ])))))))))))))))))].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
         _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[
           A21
         ]))))))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
@@ -86,6 +111,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
 
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
@@ -97,6 +128,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
+
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
         _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))))))]
@@ -107,6 +144,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
 
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
@@ -120,6 +163,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
+
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
         _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))))]
@@ -132,6 +181,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
 
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
@@ -147,6 +202,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
+
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
         _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))))]
@@ -161,6 +222,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
 
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
@@ -178,6 +245,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
+
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
         _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))))]
@@ -194,6 +267,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
 
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
@@ -213,6 +292,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
+
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
         _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))))]
@@ -231,6 +316,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
 
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
@@ -252,6 +343,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
+
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
         _.left[(F[A18] \/ (F[A19] \/ (F[A20] \/ F[A21])))]
@@ -272,6 +369,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
 
     implicit val inja17: Inj[Cop, F[A18]] =
       Inj.instance(
@@ -295,6 +398,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
+        case _                                                                                           => None
+      })
+
     implicit val inja18: Inj[Cop, F[A19]] =
       Inj.instance(
         _.left[(F[A20] \/ F[A21])]
@@ -317,6 +426,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
+        case _                                                                                                => None
+      })
 
     implicit val inja19: Inj[Cop, F[A20]] =
       Inj.instance(
@@ -342,6 +457,12 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))) => Some(x)
+        case _                                                                                                     => None
+      })
+
     implicit val inja20: Inj[Cop, F[A21]] =
       Inj.instance(
         _.right[F[A20]]
@@ -366,11 +487,19 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))) => Some(x)
+        case _                                                                                                     => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -378,11 +507,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -390,11 +523,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -402,11 +539,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -414,11 +555,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -426,11 +571,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
@@ -438,11 +587,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19) =
@@ -450,11 +603,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19) =
@@ -462,11 +619,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19))
     }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
     implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19) =
@@ -474,11 +635,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19))
     }
 
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
     implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19))
     }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
 
     implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19) =
@@ -486,11 +651,15 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19))
     }
 
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
+
     implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _))
     }
+
+    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
 
   }
 
@@ -632,6 +801,10 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18, i19, i20)).curried)))))))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor21.scala
+++ b/core/src/main/scala/andxor/AndXor21.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21] extends AndXor {
@@ -52,257 +50,404 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    }
 
-    implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma17: Prism[Cop, F[A18]] = new Prism[Cop, F[A18]] {
+      def getOption(c: Cop): Option[F[A18]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
         case _                                                                                           => None
-      })
+      }
+      def reverseGet(x: F[A18]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    }
 
-    implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
+    implicit val inja17: Inj[Cop, F[A18]] = Inj.instance(prisma17.reverseGet(_))
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] = Inj.instance(prisma17.getOption(_))
 
-    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma18: Prism[Cop, F[A19]] = new Prism[Cop, F[A19]] {
+      def getOption(c: Cop): Option[F[A19]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
         case _                                                                                                => None
-      })
+      }
+      def reverseGet(x: F[A19]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    }
 
-    implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))))
+    implicit val inja18: Inj[Cop, F[A19]] = Inj.instance(prisma18.reverseGet(_))
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] = Inj.instance(prisma18.getOption(_))
 
-    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma19: Prism[Cop, F[A20]] = new Prism[Cop, F[A20]] {
+      def getOption(c: Cop): Option[F[A20]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))) => Some(x)
         case _                                                                                                     => None
-      })
+      }
+      def reverseGet(x: F[A20]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
+    }
 
-    implicit val inja20: Inj[Cop, F[A21]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))))
+    implicit val inja19: Inj[Cop, F[A20]] = Inj.instance(prisma19.reverseGet(_))
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] = Inj.instance(prisma19.getOption(_))
 
-    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma20: Prism[Cop, F[A21]] = new Prism[Cop, F[A21]] {
+      def getOption(c: Cop): Option[F[A21]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))) => Some(x)
         case _                                                                                                     => None
-      })
+      }
+      def reverseGet(x: F[A21]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja20: Inj[Cop, F[A21]] = Inj.instance(prisma20.reverseGet(_))
+    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] = Inj.instance(prisma20.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
-    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
-      IsoSet(_._18, x => M.zero.map18(_ => x))
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
-      IsoSet(_._19, x => M.zero.map19(_ => x))
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
-    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
-      IsoSet(_._20, x => M.zero.map20(_ => x))
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
 
-    implicit def liftisoa20(implicit M: Monoid[Prod]): Prod <=> F[A21] =
-      IsoSet(_._21, x => M.zero.map21(_ => x))
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
+    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19))
+    }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
+    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19))
+    }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
+
+    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19))
+    }
+
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
+
+    implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _))
+    }
+
+    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
 
   }
 
@@ -448,8 +593,6 @@ trait AndXorK21[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor22.scala
+++ b/core/src/main/scala/andxor/AndXor22.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9], F[A10], F[A11], F[A12], F[A13], F[A14], F[A15], F[A16], F[A17], F[A18], F[A19], F[A20], F[A21], F[A22])
@@ -55,11 +54,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(
-        _.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[
-          A19
-        ] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))))))))))))))]
-      )
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -68,11 +63,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(
-        _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[
-          A20
-        ] \/ (F[A21] \/ F[A22])))))))))))))))))))].right[F[A1]]
-      )
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -81,11 +72,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(
-        _.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[
-          A21
-        ] \/ F[A22]))))))))))))))))))].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -94,11 +81,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(
-        _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[
-          A22
-        ])))))))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -107,11 +90,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(
-        _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[
-          A22
-        ]))))))))))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -120,14 +99,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(
-        _.left[(F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))))))))]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -136,15 +108,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(
-        _.left[(F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))))))))]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -153,16 +117,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(
-        _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))))))]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -171,17 +126,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(
-        _.left[(F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))))))]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {
@@ -190,18 +135,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(
-        _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))))]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
 
     implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
       Inj.instance(_ match {
@@ -210,19 +144,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(
-        _.left[(F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))))]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
 
     implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
       Inj.instance(_ match {
@@ -231,20 +153,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(
-        _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
 
     implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
       Inj.instance(_ match {
@@ -253,21 +162,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(
-        _.left[(F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
 
     implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
       Inj.instance(_ match {
@@ -276,22 +171,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(
-        _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
 
     implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
       Inj.instance(_ match {
@@ -300,23 +180,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(
-        _.left[(F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
 
     implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
       Inj.instance(_ match {
@@ -325,24 +189,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(
-        _.left[(F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
 
     implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
       Inj.instance(_ match {
@@ -351,25 +198,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(
-        _.left[(F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22]))))]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
 
     implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
       Inj.instance(_ match {
@@ -378,26 +207,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(
-        _.left[(F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
 
     implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
       Inj.instance(_ match {
@@ -406,27 +216,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(
-        _.left[(F[A20] \/ (F[A21] \/ F[A22]))]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
 
     implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
       Inj.instance(_ match {
@@ -435,28 +225,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(
-        _.left[(F[A21] \/ F[A22])]
-          .right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))))
 
     implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
       Inj.instance(_ match {
@@ -465,29 +234,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja20: Inj[Cop, F[A21]] =
-      Inj.instance(
-        _.left[F[A22]]
-          .right[F[A20]]
-          .right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))))
 
     implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
       Inj.instance(_ match {
@@ -496,29 +243,7 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       })
 
     implicit val inja21: Inj[Cop, F[A22]] =
-      Inj.instance(
-        _.right[F[A21]]
-          .right[F[A20]]
-          .right[F[A19]]
-          .right[F[A18]]
-          .right[F[A17]]
-          .right[F[A16]]
-          .right[F[A15]]
-          .right[F[A14]]
-          .right[F[A13]]
-          .right[F[A12]]
-          .right[F[A11]]
-          .right[F[A10]]
-          .right[F[A9]]
-          .right[F[A8]]
-          .right[F[A7]]
-          .right[F[A6]]
-          .right[F[A5]]
-          .right[F[A4]]
-          .right[F[A3]]
-          .right[F[A2]]
-          .right[F[A1]]
-      )
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))))
 
     implicit val inja21Inverse: Inj[Option[F[A22]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor22.scala
+++ b/core/src/main/scala/andxor/AndXor22.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -524,181 +526,71 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         case _                                                                                                          => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
+      IsoSet(_._10, x => M.zero.map10(_ => x))
 
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
+      IsoSet(_._11, x => M.zero.map11(_ => x))
 
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
+      IsoSet(_._12, x => M.zero.map12(_ => x))
 
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
+      IsoSet(_._13, x => M.zero.map13(_ => x))
 
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
+      IsoSet(_._14, x => M.zero.map14(_ => x))
 
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
+      IsoSet(_._15, x => M.zero.map15(_ => x))
 
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
+      IsoSet(_._16, x => M.zero.map16(_ => x))
 
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
+      IsoSet(_._17, x => M.zero.map17(_ => x))
 
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
+      IsoSet(_._18, x => M.zero.map18(_ => x))
 
-    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
+      IsoSet(_._19, x => M.zero.map19(_ => x))
 
-    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
+      IsoSet(_._20, x => M.zero.map20(_ => x))
 
-    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
+    implicit def liftisoa20(implicit M: Monoid[Prod]): Prod <=> F[A21] =
+      IsoSet(_._21, x => M.zero.map21(_ => x))
 
-    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
-
-    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
-
-    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
-
-    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
-
-    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
-
-    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
-
-    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20))
-    }
-
-    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
-
-    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20))
-    }
-
-    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
-
-    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20))
-    }
-
-    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
-
-    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20))
-    }
-
-    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
-
-    implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20))
-    }
-
-    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
-
-    implicit def lifta21(implicit M: Monoid[Prod]): Inj[Prod, F[A22]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _))
-    }
-
-    implicit val lifta21Inverse: Inj[F[A22], Prod] = Inj.instance(_._22)
+    implicit def liftisoa21(implicit M: Monoid[Prod]): Prod <=> F[A22] =
+      IsoSet(_._22, x => M.zero.map22(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor22.scala
+++ b/core/src/main/scala/andxor/AndXor22.scala
@@ -852,6 +852,8 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK22[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor22.scala
+++ b/core/src/main/scala/andxor/AndXor22.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22] extends AndXor {
@@ -58,12 +59,24 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ] \/ (F[A20] \/ (F[A21] \/ F[A22]))))))))))))))))))))]
       )
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(
         _.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[
           A20
         ] \/ (F[A21] \/ F[A22])))))))))))))))))))].right[F[A1]]
       )
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(
@@ -72,6 +85,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ] \/ F[A22]))))))))))))))))))].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(
         _.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[
@@ -79,12 +98,24 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
         ])))))))))))))))))].right[F[A3]].right[F[A2]].right[F[A1]]
       )
 
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
+
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(
         _.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ (F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[
           A22
         ]))))))))))))))))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]]
       )
+
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
 
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(
@@ -95,6 +126,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(
@@ -107,6 +144,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(
         _.left[(F[A9] \/ (F[A10] \/ (F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))))))]
@@ -118,6 +161,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(
@@ -132,6 +181,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
+        case _                                              => None
+      })
+
     implicit val inja9: Inj[Cop, F[A10]] =
       Inj.instance(
         _.left[(F[A11] \/ (F[A12] \/ (F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))))]
@@ -145,6 +200,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
+        case _                                                   => None
+      })
 
     implicit val inja10: Inj[Cop, F[A11]] =
       Inj.instance(
@@ -161,6 +222,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
+        case _                                                        => None
+      })
+
     implicit val inja11: Inj[Cop, F[A12]] =
       Inj.instance(
         _.left[(F[A13] \/ (F[A14] \/ (F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))))]
@@ -176,6 +243,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
+        case _                                                             => None
+      })
 
     implicit val inja12: Inj[Cop, F[A13]] =
       Inj.instance(
@@ -194,6 +267,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
+        case _                                                                  => None
+      })
+
     implicit val inja13: Inj[Cop, F[A14]] =
       Inj.instance(
         _.left[(F[A15] \/ (F[A16] \/ (F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))))]
@@ -211,6 +290,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
+        case _                                                                       => None
+      })
 
     implicit val inja14: Inj[Cop, F[A15]] =
       Inj.instance(
@@ -231,6 +316,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
+        case _                                                                            => None
+      })
+
     implicit val inja15: Inj[Cop, F[A16]] =
       Inj.instance(
         _.left[(F[A17] \/ (F[A18] \/ (F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))))]
@@ -250,6 +341,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
+        case _                                                                                 => None
+      })
 
     implicit val inja16: Inj[Cop, F[A17]] =
       Inj.instance(
@@ -272,6 +369,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
+        case _                                                                                      => None
+      })
+
     implicit val inja17: Inj[Cop, F[A18]] =
       Inj.instance(
         _.left[(F[A19] \/ (F[A20] \/ (F[A21] \/ F[A22])))]
@@ -293,6 +396,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
+        case _                                                                                           => None
+      })
 
     implicit val inja18: Inj[Cop, F[A19]] =
       Inj.instance(
@@ -317,6 +426,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
+        case _                                                                                                => None
+      })
+
     implicit val inja19: Inj[Cop, F[A20]] =
       Inj.instance(
         _.left[(F[A21] \/ F[A22])]
@@ -340,6 +455,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A2]]
           .right[F[A1]]
       )
+
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))) => Some(x)
+        case _                                                                                                     => None
+      })
 
     implicit val inja20: Inj[Cop, F[A21]] =
       Inj.instance(
@@ -366,6 +487,12 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))) => Some(x)
+        case _                                                                                                          => None
+      })
+
     implicit val inja21: Inj[Cop, F[A22]] =
       Inj.instance(
         _.right[F[A21]]
@@ -391,11 +518,19 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
           .right[F[A1]]
       )
 
+    implicit val inja21Inverse: Inj[Option[F[A22]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))) => Some(x)
+        case _                                                                                                          => None
+      })
+
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -403,11 +538,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -415,11 +554,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -427,11 +570,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -439,11 +586,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
     implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -451,11 +602,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
+
     implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
 
     implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -463,11 +618,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
     implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
 
     implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20) =
@@ -475,11 +634,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
     implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
 
     implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20) =
@@ -487,11 +650,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20))
     }
 
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
     implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20))
     }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
 
     implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20) =
@@ -499,11 +666,15 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20))
     }
 
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
     implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20))
     }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
 
     implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20) =
@@ -511,17 +682,23 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20))
     }
 
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
+
     implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20))
     }
 
+    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
+
     implicit def lifta21(implicit M: Monoid[Prod]): Inj[Prod, F[A22]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _))
     }
+
+    implicit val lifta21Inverse: Inj[F[A22], Prod] = Inj.instance(_._22)
 
   }
 
@@ -670,6 +847,10 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
     (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16, i17, i18, i19, i20, i21)).curried))))))))))))))))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor22.scala
+++ b/core/src/main/scala/andxor/AndXor22.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22] extends AndXor {
@@ -53,269 +51,423 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))) => Some(x)
         case _                                              => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    }
 
-    implicit val inja9: Inj[Cop, F[A10]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma9: Prism[Cop, F[A10]] = new Prism[Cop, F[A10]] {
+      def getOption(c: Cop): Option[F[A10]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))) => Some(x)
         case _                                                   => None
-      })
+      }
+      def reverseGet(x: F[A10]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))
+    }
 
-    implicit val inja10: Inj[Cop, F[A11]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    implicit val inja9: Inj[Cop, F[A10]] = Inj.instance(prisma9.reverseGet(_))
+    implicit val inja9Inverse: Inj[Option[F[A10]], Cop] = Inj.instance(prisma9.getOption(_))
 
-    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma10: Prism[Cop, F[A11]] = new Prism[Cop, F[A11]] {
+      def getOption(c: Cop): Option[F[A11]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))) => Some(x)
         case _                                                        => None
-      })
+      }
+      def reverseGet(x: F[A11]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))
+    }
 
-    implicit val inja11: Inj[Cop, F[A12]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    implicit val inja10: Inj[Cop, F[A11]] = Inj.instance(prisma10.reverseGet(_))
+    implicit val inja10Inverse: Inj[Option[F[A11]], Cop] = Inj.instance(prisma10.getOption(_))
 
-    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma11: Prism[Cop, F[A12]] = new Prism[Cop, F[A12]] {
+      def getOption(c: Cop): Option[F[A12]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))) => Some(x)
         case _                                                             => None
-      })
+      }
+      def reverseGet(x: F[A12]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))
+    }
 
-    implicit val inja12: Inj[Cop, F[A13]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    implicit val inja11: Inj[Cop, F[A12]] = Inj.instance(prisma11.reverseGet(_))
+    implicit val inja11Inverse: Inj[Option[F[A12]], Cop] = Inj.instance(prisma11.getOption(_))
 
-    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma12: Prism[Cop, F[A13]] = new Prism[Cop, F[A13]] {
+      def getOption(c: Cop): Option[F[A13]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))) => Some(x)
         case _                                                                  => None
-      })
+      }
+      def reverseGet(x: F[A13]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))
+    }
 
-    implicit val inja13: Inj[Cop, F[A14]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    implicit val inja12: Inj[Cop, F[A13]] = Inj.instance(prisma12.reverseGet(_))
+    implicit val inja12Inverse: Inj[Option[F[A13]], Cop] = Inj.instance(prisma12.getOption(_))
 
-    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma13: Prism[Cop, F[A14]] = new Prism[Cop, F[A14]] {
+      def getOption(c: Cop): Option[F[A14]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))) => Some(x)
         case _                                                                       => None
-      })
+      }
+      def reverseGet(x: F[A14]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))
+    }
 
-    implicit val inja14: Inj[Cop, F[A15]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    implicit val inja13: Inj[Cop, F[A14]] = Inj.instance(prisma13.reverseGet(_))
+    implicit val inja13Inverse: Inj[Option[F[A14]], Cop] = Inj.instance(prisma13.getOption(_))
 
-    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma14: Prism[Cop, F[A15]] = new Prism[Cop, F[A15]] {
+      def getOption(c: Cop): Option[F[A15]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))) => Some(x)
         case _                                                                            => None
-      })
+      }
+      def reverseGet(x: F[A15]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))
+    }
 
-    implicit val inja15: Inj[Cop, F[A16]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    implicit val inja14: Inj[Cop, F[A15]] = Inj.instance(prisma14.reverseGet(_))
+    implicit val inja14Inverse: Inj[Option[F[A15]], Cop] = Inj.instance(prisma14.getOption(_))
 
-    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma15: Prism[Cop, F[A16]] = new Prism[Cop, F[A16]] {
+      def getOption(c: Cop): Option[F[A16]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))) => Some(x)
         case _                                                                                 => None
-      })
+      }
+      def reverseGet(x: F[A16]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))
+    }
 
-    implicit val inja16: Inj[Cop, F[A17]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    implicit val inja15: Inj[Cop, F[A16]] = Inj.instance(prisma15.reverseGet(_))
+    implicit val inja15Inverse: Inj[Option[F[A16]], Cop] = Inj.instance(prisma15.getOption(_))
 
-    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma16: Prism[Cop, F[A17]] = new Prism[Cop, F[A17]] {
+      def getOption(c: Cop): Option[F[A17]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))) => Some(x)
         case _                                                                                      => None
-      })
+      }
+      def reverseGet(x: F[A17]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))
+    }
 
-    implicit val inja17: Inj[Cop, F[A18]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    implicit val inja16: Inj[Cop, F[A17]] = Inj.instance(prisma16.reverseGet(_))
+    implicit val inja16Inverse: Inj[Option[F[A17]], Cop] = Inj.instance(prisma16.getOption(_))
 
-    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma17: Prism[Cop, F[A18]] = new Prism[Cop, F[A18]] {
+      def getOption(c: Cop): Option[F[A18]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))) => Some(x)
         case _                                                                                           => None
-      })
+      }
+      def reverseGet(x: F[A18]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))
+    }
 
-    implicit val inja18: Inj[Cop, F[A19]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
+    implicit val inja17: Inj[Cop, F[A18]] = Inj.instance(prisma17.reverseGet(_))
+    implicit val inja17Inverse: Inj[Option[F[A18]], Cop] = Inj.instance(prisma17.getOption(_))
 
-    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma18: Prism[Cop, F[A19]] = new Prism[Cop, F[A19]] {
+      def getOption(c: Cop): Option[F[A19]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))) => Some(x)
         case _                                                                                                => None
-      })
+      }
+      def reverseGet(x: F[A19]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))
+    }
 
-    implicit val inja19: Inj[Cop, F[A20]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))))
+    implicit val inja18: Inj[Cop, F[A19]] = Inj.instance(prisma18.reverseGet(_))
+    implicit val inja18Inverse: Inj[Option[F[A19]], Cop] = Inj.instance(prisma18.getOption(_))
 
-    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma19: Prism[Cop, F[A20]] = new Prism[Cop, F[A20]] {
+      def getOption(c: Cop): Option[F[A20]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))) => Some(x)
         case _                                                                                                     => None
-      })
+      }
+      def reverseGet(x: F[A20]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))
+    }
 
-    implicit val inja20: Inj[Cop, F[A21]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))))
+    implicit val inja19: Inj[Cop, F[A20]] = Inj.instance(prisma19.reverseGet(_))
+    implicit val inja19Inverse: Inj[Option[F[A20]], Cop] = Inj.instance(prisma19.getOption(_))
 
-    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma20: Prism[Cop, F[A21]] = new Prism[Cop, F[A21]] {
+      def getOption(c: Cop): Option[F[A21]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))))))))))))))) => Some(x)
         case _                                                                                                          => None
-      })
+      }
+      def reverseGet(x: F[A21]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))))))))))))))
+    }
 
-    implicit val inja21: Inj[Cop, F[A22]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))))
+    implicit val inja20: Inj[Cop, F[A21]] = Inj.instance(prisma20.reverseGet(_))
+    implicit val inja20Inverse: Inj[Option[F[A21]], Cop] = Inj.instance(prisma20.getOption(_))
 
-    implicit val inja21Inverse: Inj[Option[F[A22]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma21: Prism[Cop, F[A22]] = new Prism[Cop, F[A22]] {
+      def getOption(c: Cop): Option[F[A22]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))))))))))))))) => Some(x)
         case _                                                                                                          => None
-      })
+      }
+      def reverseGet(x: F[A22]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))))))))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja21: Inj[Cop, F[A22]] = Inj.instance(prisma21.reverseGet(_))
+    implicit val inja21Inverse: Inj[Option[F[A22]], Cop] = Inj.instance(prisma21.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
-    implicit def liftisoa9(implicit M: Monoid[Prod]): Prod <=> F[A10] =
-      IsoSet(_._10, x => M.zero.map10(_ => x))
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa10(implicit M: Monoid[Prod]): Prod <=> F[A11] =
-      IsoSet(_._11, x => M.zero.map11(_ => x))
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
-    implicit def liftisoa11(implicit M: Monoid[Prod]): Prod <=> F[A12] =
-      IsoSet(_._12, x => M.zero.map12(_ => x))
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa12(implicit M: Monoid[Prod]): Prod <=> F[A13] =
-      IsoSet(_._13, x => M.zero.map13(_ => x))
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
-    implicit def liftisoa13(implicit M: Monoid[Prod]): Prod <=> F[A14] =
-      IsoSet(_._14, x => M.zero.map14(_ => x))
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa14(implicit M: Monoid[Prod]): Prod <=> F[A15] =
-      IsoSet(_._15, x => M.zero.map15(_ => x))
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
-    implicit def liftisoa15(implicit M: Monoid[Prod]): Prod <=> F[A16] =
-      IsoSet(_._16, x => M.zero.map16(_ => x))
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa16(implicit M: Monoid[Prod]): Prod <=> F[A17] =
-      IsoSet(_._17, x => M.zero.map17(_ => x))
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
-    implicit def liftisoa17(implicit M: Monoid[Prod]): Prod <=> F[A18] =
-      IsoSet(_._18, x => M.zero.map18(_ => x))
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa18(implicit M: Monoid[Prod]): Prod <=> F[A19] =
-      IsoSet(_._19, x => M.zero.map19(_ => x))
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
-    implicit def liftisoa19(implicit M: Monoid[Prod]): Prod <=> F[A20] =
-      IsoSet(_._20, x => M.zero.map20(_ => x))
+    implicit def lifta9(implicit M: Monoid[Prod]): Inj[Prod, F[A10]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, _, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
 
-    implicit def liftisoa20(implicit M: Monoid[Prod]): Prod <=> F[A21] =
-      IsoSet(_._21, x => M.zero.map21(_ => x))
+    implicit val lifta9Inverse: Inj[F[A10], Prod] = Inj.instance(_._10)
 
-    implicit def liftisoa21(implicit M: Monoid[Prod]): Prod <=> F[A22] =
-      IsoSet(_._22, x => M.zero.map22(_ => x))
+    implicit def lifta10(implicit M: Monoid[Prod]): Inj[Prod, F[A11]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, _, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta10Inverse: Inj[F[A11], Prod] = Inj.instance(_._11)
+
+    implicit def lifta11(implicit M: Monoid[Prod]): Inj[Prod, F[A12]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, _, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta11Inverse: Inj[F[A12], Prod] = Inj.instance(_._12)
+
+    implicit def lifta12(implicit M: Monoid[Prod]): Inj[Prod, F[A13]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, _, a12, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta12Inverse: Inj[F[A13], Prod] = Inj.instance(_._13)
+
+    implicit def lifta13(implicit M: Monoid[Prod]): Inj[Prod, F[A14]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, _, a13, a14, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta13Inverse: Inj[F[A14], Prod] = Inj.instance(_._14)
+
+    implicit def lifta14(implicit M: Monoid[Prod]): Inj[Prod, F[A15]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, _, a14, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta14Inverse: Inj[F[A15], Prod] = Inj.instance(_._15)
+
+    implicit def lifta15(implicit M: Monoid[Prod]): Inj[Prod, F[A16]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, _, a15, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta15Inverse: Inj[F[A16], Prod] = Inj.instance(_._16)
+
+    implicit def lifta16(implicit M: Monoid[Prod]): Inj[Prod, F[A17]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, _, a16, a17, a18, a19, a20))
+    }
+
+    implicit val lifta16Inverse: Inj[F[A17], Prod] = Inj.instance(_._17)
+
+    implicit def lifta17(implicit M: Monoid[Prod]): Inj[Prod, F[A18]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, _, a17, a18, a19, a20))
+    }
+
+    implicit val lifta17Inverse: Inj[F[A18], Prod] = Inj.instance(_._18)
+
+    implicit def lifta18(implicit M: Monoid[Prod]): Inj[Prod, F[A19]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, _, a18, a19, a20))
+    }
+
+    implicit val lifta18Inverse: Inj[F[A19], Prod] = Inj.instance(_._19)
+
+    implicit def lifta19(implicit M: Monoid[Prod]): Inj[Prod, F[A20]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, _, a19, a20))
+    }
+
+    implicit val lifta19Inverse: Inj[F[A20], Prod] = Inj.instance(_._20)
+
+    implicit def lifta20(implicit M: Monoid[Prod]): Inj[Prod, F[A21]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, _, a20))
+    }
+
+    implicit val lifta20Inverse: Inj[F[A21], Prod] = Inj.instance(_._21)
+
+    implicit def lifta21(implicit M: Monoid[Prod]): Inj[Prod, F[A22]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, _))
+    }
+
+    implicit val lifta21Inverse: Inj[F[A22], Prod] = Inj.instance(_._22)
 
   }
 
@@ -468,8 +620,6 @@ trait AndXorK22[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A1
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor3.scala
+++ b/core/src/main/scala/andxor/AndXor3.scala
@@ -102,6 +102,8 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK3[Id, A1, A2, A3]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor3.scala
+++ b/core/src/main/scala/andxor/AndXor3.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
@@ -25,41 +23,62 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(x)))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(x))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1) =
+        M.zero
+      Inj.instance((_, a0, a1))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1) =
+        M.zero
+      Inj.instance((a0, _, a1))
+    }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _) =
+        M.zero
+      Inj.instance((a0, a1, _))
+    }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
   }
 
@@ -87,8 +106,6 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor3.scala
+++ b/core/src/main/scala/andxor/AndXor3.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3])
@@ -27,7 +26,7 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ F[A3])])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[F[A3]].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(x)))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor3.scala
+++ b/core/src/main/scala/andxor/AndXor3.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -51,29 +53,14 @@ trait AndXorK3[F[_], A1, A2, A3] extends AndXor {
         case _           => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1) =
-        M.zero
-      Inj.instance((_, a0, a1))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1) =
-        M.zero
-      Inj.instance((a0, _, a1))
-    }
-
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
-
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _) =
-        M.zero
-      Inj.instance((a0, a1, _))
-    }
-
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor4.scala
+++ b/core/src/main/scala/andxor/AndXor4.scala
@@ -120,6 +120,8 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK4[Id, A1, A2, A3, A4]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor4.scala
+++ b/core/src/main/scala/andxor/AndXor4.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -60,37 +62,17 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
         case _                => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2) =
-        M.zero
-      Inj.instance((_, a0, a1, a2))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2) =
-        M.zero
-      Inj.instance((a0, _, a1, a2))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
-
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2) =
-        M.zero
-      Inj.instance((a0, a1, _, a2))
-    }
-
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
-
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, _))
-    }
-
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor4.scala
+++ b/core/src/main/scala/andxor/AndXor4.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
@@ -26,14 +27,38 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ F[A4]))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ F[A4])].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[F[A4]].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(x))) => Some(x)
+        case _                => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2) =
@@ -41,11 +66,15 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
       Inj.instance((_, a0, a1, a2))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2) =
         M.zero
       Inj.instance((a0, _, a1, a2))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2) =
@@ -53,11 +82,15 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
       Inj.instance((a0, a1, _, a2))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _) =
         M.zero
       Inj.instance((a0, a1, a2, _))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
   }
 
@@ -82,6 +115,10 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
     (i0, i1, i2, i3)).curried))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor4.scala
+++ b/core/src/main/scala/andxor/AndXor4.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
@@ -25,53 +23,81 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(x))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(x)))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2) =
+        M.zero
+      Inj.instance((_, a0, a1, a2))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2) =
+        M.zero
+      Inj.instance((a0, _, a1, a2))
+    }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2) =
+        M.zero
+      Inj.instance((a0, a1, _, a2))
+    }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, _))
+    }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
   }
 
@@ -100,8 +126,6 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor4.scala
+++ b/core/src/main/scala/andxor/AndXor4.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4])
@@ -27,7 +26,7 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ F[A4]))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ F[A4])].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[F[A4]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK4[F[_], A1, A2, A3, A4] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(x))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor5.scala
+++ b/core/src/main/scala/andxor/AndXor5.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
@@ -25,65 +23,100 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(x)))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(x))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3))
+    }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3))
+    }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
   }
 
@@ -113,8 +146,6 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor5.scala
+++ b/core/src/main/scala/andxor/AndXor5.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
@@ -26,17 +27,47 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ F[A5])))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ F[A5]))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ F[A5])].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[F[A5]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
+
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3) =
@@ -44,11 +75,15 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3) =
@@ -56,17 +91,23 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3))
     }
 
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, _))
     }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
 
   }
 
@@ -92,6 +133,10 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
     (i0, i1, i2, i3, i4)).curried)))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor5.scala
+++ b/core/src/main/scala/andxor/AndXor5.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5])
@@ -27,7 +26,7 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ F[A5])))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ F[A5]))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ F[A5])].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[F[A5]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(x)))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor5.scala
+++ b/core/src/main/scala/andxor/AndXor5.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -69,45 +71,20 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
         case _                     => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3))
-    }
-
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
-
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3))
-    }
-
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
-
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _))
-    }
-
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor5.scala
+++ b/core/src/main/scala/andxor/AndXor5.scala
@@ -138,6 +138,8 @@ trait AndXorK5[F[_], A1, A2, A3, A4, A5] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK5[Id, A1, A2, A3, A4, A5]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor6.scala
+++ b/core/src/main/scala/andxor/AndXor6.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
@@ -25,77 +23,119 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(x))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(x)))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4))
+    }
+
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4))
+    }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
   }
 
@@ -126,8 +166,6 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor6.scala
+++ b/core/src/main/scala/andxor/AndXor6.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6])
@@ -27,7 +26,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ F[A6]))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ F[A6])))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ F[A6]))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ F[A6])].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[F[A6]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(x))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor6.scala
+++ b/core/src/main/scala/andxor/AndXor6.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -78,53 +80,23 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
         case _                          => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
-
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4))
-    }
-
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
-
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4))
-    }
-
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
-
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor6.scala
+++ b/core/src/main/scala/andxor/AndXor6.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
@@ -26,20 +27,56 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ F[A6]))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ F[A6])))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ F[A6]))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ F[A6])].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[F[A6]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(x))))) => Some(x)
+        case _                          => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4) =
@@ -47,11 +84,15 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3, a4))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4) =
@@ -59,11 +100,15 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3, a4))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4) =
@@ -71,11 +116,15 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
       Inj.instance((a0, a1, a2, a3, _, a4))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
   }
 
@@ -102,6 +151,10 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
     (i0, i1, i2, i3, i4, i5)).curried))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor6.scala
+++ b/core/src/main/scala/andxor/AndXor6.scala
@@ -156,6 +156,8 @@ trait AndXorK6[F[_], A1, A2, A3, A4, A5, A6] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK6[Id, A1, A2, A3, A4, A5, A6]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor7.scala
+++ b/core/src/main/scala/andxor/AndXor7.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
@@ -26,23 +27,65 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7])))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7]))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7])))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ F[A7]))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ F[A7])].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[F[A7]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
+
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5) =
@@ -50,11 +93,15 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3, a4, a5))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5) =
@@ -62,11 +109,15 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3, a4, a5))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5) =
@@ -74,17 +125,23 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       Inj.instance((a0, a1, a2, a3, _, a4, a5))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5))
     }
 
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, _))
     }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
   }
 
@@ -112,6 +169,10 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
     (i0, i1, i2, i3, i4, i5, i6)).curried)))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor7.scala
+++ b/core/src/main/scala/andxor/AndXor7.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -87,61 +89,26 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
         case _                               => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5))
-    }
-
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
-
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5))
-    }
-
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
-
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor7.scala
+++ b/core/src/main/scala/andxor/AndXor7.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
@@ -25,89 +23,138 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(x)))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(x))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5))
+    }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
 
   }
 
@@ -139,8 +186,6 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor7.scala
+++ b/core/src/main/scala/andxor/AndXor7.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7])
@@ -27,7 +26,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7])))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7]))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ F[A7])))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ F[A7]))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ F[A7])].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[F[A7]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -81,7 +80,7 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(x)))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor7.scala
+++ b/core/src/main/scala/andxor/AndXor7.scala
@@ -174,6 +174,8 @@ trait AndXorK7[F[_], A1, A2, A3, A4, A5, A6, A7] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK7[Id, A1, A2, A3, A4, A5, A6, A7]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor8.scala
+++ b/core/src/main/scala/andxor/AndXor8.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8])
@@ -27,7 +26,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8]))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8])))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8]))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8])))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ F[A8]))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ F[A8])].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -81,7 +80,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[F[A8]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -90,7 +89,7 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor8.scala
+++ b/core/src/main/scala/andxor/AndXor8.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
@@ -25,101 +23,157 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6))
+    }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
   }
 
@@ -152,8 +206,6 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor8.scala
+++ b/core/src/main/scala/andxor/AndXor8.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -96,69 +98,29 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
         case _                                    => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
-
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6))
-    }
-
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
-
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor8.scala
+++ b/core/src/main/scala/andxor/AndXor8.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
@@ -26,26 +27,74 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8]))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8])))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8]))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ F[A8])))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ F[A8]))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ F[A8])].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[F[A8]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))) => Some(x)
+        case _                                    => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6) =
@@ -53,11 +102,15 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6) =
@@ -65,11 +118,15 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6) =
@@ -77,11 +134,15 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6) =
@@ -89,11 +150,15 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _))
     }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
 
   }
 
@@ -122,6 +187,10 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
     (i0, i1, i2, i3, i4, i5, i6, i7)).curried))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor8.scala
+++ b/core/src/main/scala/andxor/AndXor8.scala
@@ -192,6 +192,8 @@ trait AndXorK8[F[_], A1, A2, A3, A4, A5, A6, A7, A8] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK8[Id, A1, A2, A3, A4, A5, A6, A7, A8]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor9.scala
+++ b/core/src/main/scala/andxor/AndXor9.scala
@@ -210,6 +210,8 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK9[Id, A1, A2, A3, A4, A5, A6, A7, A8, A9]#Cop], M: Monoid[C],

--- a/core/src/main/scala/andxor/AndXor9.scala
+++ b/core/src/main/scala/andxor/AndXor9.scala
@@ -5,7 +5,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
   type Prod = (F[A1], F[A2], F[A3], F[A4], F[A5], F[A6], F[A7], F[A8], F[A9])
@@ -27,7 +26,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
   object instances {
 
     implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))))))])
+      Inj.instance(x => -\/(x))
 
     implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
       Inj.instance(_ match {
@@ -36,7 +35,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9]))))))].right[F[A1]])
+      Inj.instance(x => \/-(-\/(x)))
 
     implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
       Inj.instance(_ match {
@@ -45,7 +44,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))))].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(-\/(x))))
 
     implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
       Inj.instance(_ match {
@@ -54,7 +53,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9]))))].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
 
     implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
       Inj.instance(_ match {
@@ -63,7 +62,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
 
     implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
       Inj.instance(_ match {
@@ -72,7 +71,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(_.left[(F[A7] \/ (F[A8] \/ F[A9]))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
 
     implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
       Inj.instance(_ match {
@@ -81,7 +80,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(_.left[(F[A8] \/ F[A9])].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
 
     implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
       Inj.instance(_ match {
@@ -90,7 +89,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(_.left[F[A9]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
 
     implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
       Inj.instance(_ match {
@@ -99,7 +98,7 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       })
 
     implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(_.right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))
 
     implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
       Inj.instance(_ match {

--- a/core/src/main/scala/andxor/AndXor9.scala
+++ b/core/src/main/scala/andxor/AndXor9.scala
@@ -2,6 +2,7 @@ package andxor
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
@@ -26,29 +27,83 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
     implicit val inja0: Inj[Cop, F[A1]] =
       Inj.instance(_.left[(F[A2] \/ (F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))))))])
 
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
+      Inj.instance(_ match {
+        case -\/(x) => Some(x)
+        case _      => None
+      })
+
     implicit val inja1: Inj[Cop, F[A2]] =
       Inj.instance(_.left[(F[A3] \/ (F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9]))))))].right[F[A1]])
+
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
+      Inj.instance(_ match {
+        case \/-(-\/(x)) => Some(x)
+        case _           => None
+      })
 
     implicit val inja2: Inj[Cop, F[A3]] =
       Inj.instance(_.left[(F[A4] \/ (F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))))].right[F[A2]].right[F[A1]])
 
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(-\/(x))) => Some(x)
+        case _                => None
+      })
+
     implicit val inja3: Inj[Cop, F[A4]] =
       Inj.instance(_.left[(F[A5] \/ (F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9]))))].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(-\/(x)))) => Some(x)
+        case _                     => None
+      })
 
     implicit val inja4: Inj[Cop, F[A5]] =
       Inj.instance(_.left[(F[A6] \/ (F[A7] \/ (F[A8] \/ F[A9])))].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
+        case _                          => None
+      })
+
     implicit val inja5: Inj[Cop, F[A6]] =
       Inj.instance(_.left[(F[A7] \/ (F[A8] \/ F[A9]))].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
+        case _                               => None
+      })
 
     implicit val inja6: Inj[Cop, F[A7]] =
       Inj.instance(_.left[(F[A8] \/ F[A9])].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
+        case _                                    => None
+      })
+
     implicit val inja7: Inj[Cop, F[A8]] =
       Inj.instance(_.left[F[A9]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
 
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
+        case _                                         => None
+      })
+
     implicit val inja8: Inj[Cop, F[A9]] =
       Inj.instance(_.right[F[A8]].right[F[A7]].right[F[A6]].right[F[A5]].right[F[A4]].right[F[A3]].right[F[A2]].right[F[A1]])
+
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
+      Inj.instance(_ match {
+        case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))) => Some(x)
+        case _                                         => None
+      })
 
     implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
       val (_, a0, a1, a2, a3, a4, a5, a6, a7) =
@@ -56,11 +111,15 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7))
     }
 
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+
     implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
       val (a0, _, a1, a2, a3, a4, a5, a6, a7) =
         M.zero
       Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7))
     }
+
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
     implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
       val (a0, a1, _, a2, a3, a4, a5, a6, a7) =
@@ -68,11 +127,15 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7))
     }
 
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+
     implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
       val (a0, a1, a2, _, a3, a4, a5, a6, a7) =
         M.zero
       Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7))
     }
+
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
 
     implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
       val (a0, a1, a2, a3, _, a4, a5, a6, a7) =
@@ -80,11 +143,15 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7))
     }
 
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
     implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
       val (a0, a1, a2, a3, a4, _, a5, a6, a7) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7))
     }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
 
     implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
       val (a0, a1, a2, a3, a4, a5, _, a6, a7) =
@@ -92,17 +159,23 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
       Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7))
     }
 
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
     implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
       val (a0, a1, a2, a3, a4, a5, a6, _, a7) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7))
     }
 
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
     implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
       val (a0, a1, a2, a3, a4, a5, a6, a7, _) =
         M.zero
       Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _))
     }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
   }
 
@@ -132,6 +205,10 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
     (i0, i1, i2, i3, i4, i5, i6, i7, i8)).curried)))))))))
   }
   
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/AndXor9.scala
+++ b/core/src/main/scala/andxor/AndXor9.scala
@@ -1,7 +1,9 @@
 package andxor
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 
@@ -105,77 +107,32 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
         case _                                         => None
       })
 
-    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
-      val (_, a0, a1, a2, a3, a4, a5, a6, a7) =
-        M.zero
-      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7))
-    }
+    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
+      IsoSet(_._1, x => M.zero.map1(_ => x))
 
-    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
+    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
+      IsoSet(_._2, x => M.zero.map2(_ => x))
 
-    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
-      val (a0, _, a1, a2, a3, a4, a5, a6, a7) =
-        M.zero
-      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7))
-    }
+    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
+      IsoSet(_._3, x => M.zero.map3(_ => x))
 
-    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
+    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
+      IsoSet(_._4, x => M.zero.map4(_ => x))
 
-    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
-      val (a0, a1, _, a2, a3, a4, a5, a6, a7) =
-        M.zero
-      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7))
-    }
+    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
+      IsoSet(_._5, x => M.zero.map5(_ => x))
 
-    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
+    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
+      IsoSet(_._6, x => M.zero.map6(_ => x))
 
-    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
-      val (a0, a1, a2, _, a3, a4, a5, a6, a7) =
-        M.zero
-      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7))
-    }
+    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
+      IsoSet(_._7, x => M.zero.map7(_ => x))
 
-    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
+      IsoSet(_._8, x => M.zero.map8(_ => x))
 
-    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
-      val (a0, a1, a2, a3, _, a4, a5, a6, a7) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7))
-    }
-
-    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
-
-    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
-      val (a0, a1, a2, a3, a4, _, a5, a6, a7) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7))
-    }
-
-    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
-
-    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
-      val (a0, a1, a2, a3, a4, a5, _, a6, a7) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7))
-    }
-
-    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
-
-    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, _, a7) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7))
-    }
-
-    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
-
-    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
-      val (a0, a1, a2, a3, a4, a5, a6, a7, _) =
-        M.zero
-      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _))
-    }
-
-    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
+    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
+      IsoSet(_._9, x => M.zero.map9(_ => x))
 
   }
 

--- a/core/src/main/scala/andxor/AndXor9.scala
+++ b/core/src/main/scala/andxor/AndXor9.scala
@@ -1,9 +1,7 @@
 package andxor
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
@@ -25,113 +23,176 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
 
   object instances {
 
-    implicit val inja0: Inj[Cop, F[A1]] =
-      Inj.instance(x => -\/(x))
-
-    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma0: Prism[Cop, F[A1]] = new Prism[Cop, F[A1]] {
+      def getOption(c: Cop): Option[F[A1]] = c match {
         case -\/(x) => Some(x)
         case _      => None
-      })
+      }
+      def reverseGet(x: F[A1]): Cop = -\/(x)
+    }
 
-    implicit val inja1: Inj[Cop, F[A2]] =
-      Inj.instance(x => \/-(-\/(x)))
+    implicit val inja0: Inj[Cop, F[A1]] = Inj.instance(prisma0.reverseGet(_))
+    implicit val inja0Inverse: Inj[Option[F[A1]], Cop] = Inj.instance(prisma0.getOption(_))
 
-    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma1: Prism[Cop, F[A2]] = new Prism[Cop, F[A2]] {
+      def getOption(c: Cop): Option[F[A2]] = c match {
         case \/-(-\/(x)) => Some(x)
         case _           => None
-      })
+      }
+      def reverseGet(x: F[A2]): Cop = \/-(-\/(x))
+    }
 
-    implicit val inja2: Inj[Cop, F[A3]] =
-      Inj.instance(x => \/-(\/-(-\/(x))))
+    implicit val inja1: Inj[Cop, F[A2]] = Inj.instance(prisma1.reverseGet(_))
+    implicit val inja1Inverse: Inj[Option[F[A2]], Cop] = Inj.instance(prisma1.getOption(_))
 
-    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma2: Prism[Cop, F[A3]] = new Prism[Cop, F[A3]] {
+      def getOption(c: Cop): Option[F[A3]] = c match {
         case \/-(\/-(-\/(x))) => Some(x)
         case _                => None
-      })
+      }
+      def reverseGet(x: F[A3]): Cop = \/-(\/-(-\/(x)))
+    }
 
-    implicit val inja3: Inj[Cop, F[A4]] =
-      Inj.instance(x => \/-(\/-(\/-(-\/(x)))))
+    implicit val inja2: Inj[Cop, F[A3]] = Inj.instance(prisma2.reverseGet(_))
+    implicit val inja2Inverse: Inj[Option[F[A3]], Cop] = Inj.instance(prisma2.getOption(_))
 
-    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma3: Prism[Cop, F[A4]] = new Prism[Cop, F[A4]] {
+      def getOption(c: Cop): Option[F[A4]] = c match {
         case \/-(\/-(\/-(-\/(x)))) => Some(x)
         case _                     => None
-      })
+      }
+      def reverseGet(x: F[A4]): Cop = \/-(\/-(\/-(-\/(x))))
+    }
 
-    implicit val inja4: Inj[Cop, F[A5]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(-\/(x))))))
+    implicit val inja3: Inj[Cop, F[A4]] = Inj.instance(prisma3.reverseGet(_))
+    implicit val inja3Inverse: Inj[Option[F[A4]], Cop] = Inj.instance(prisma3.getOption(_))
 
-    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma4: Prism[Cop, F[A5]] = new Prism[Cop, F[A5]] {
+      def getOption(c: Cop): Option[F[A5]] = c match {
         case \/-(\/-(\/-(\/-(-\/(x))))) => Some(x)
         case _                          => None
-      })
+      }
+      def reverseGet(x: F[A5]): Cop = \/-(\/-(\/-(\/-(-\/(x)))))
+    }
 
-    implicit val inja5: Inj[Cop, F[A6]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    implicit val inja4: Inj[Cop, F[A5]] = Inj.instance(prisma4.reverseGet(_))
+    implicit val inja4Inverse: Inj[Option[F[A5]], Cop] = Inj.instance(prisma4.getOption(_))
 
-    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma5: Prism[Cop, F[A6]] = new Prism[Cop, F[A6]] {
+      def getOption(c: Cop): Option[F[A6]] = c match {
         case \/-(\/-(\/-(\/-(\/-(-\/(x)))))) => Some(x)
         case _                               => None
-      })
+      }
+      def reverseGet(x: F[A6]): Cop = \/-(\/-(\/-(\/-(\/-(-\/(x))))))
+    }
 
-    implicit val inja6: Inj[Cop, F[A7]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    implicit val inja5: Inj[Cop, F[A6]] = Inj.instance(prisma5.reverseGet(_))
+    implicit val inja5Inverse: Inj[Option[F[A6]], Cop] = Inj.instance(prisma5.getOption(_))
 
-    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma6: Prism[Cop, F[A7]] = new Prism[Cop, F[A7]] {
+      def getOption(c: Cop): Option[F[A7]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))) => Some(x)
         case _                                    => None
-      })
+      }
+      def reverseGet(x: F[A7]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))
+    }
 
-    implicit val inja7: Inj[Cop, F[A8]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))))
+    implicit val inja6: Inj[Cop, F[A7]] = Inj.instance(prisma6.reverseGet(_))
+    implicit val inja6Inverse: Inj[Option[F[A7]], Cop] = Inj.instance(prisma6.getOption(_))
 
-    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma7: Prism[Cop, F[A8]] = new Prism[Cop, F[A8]] {
+      def getOption(c: Cop): Option[F[A8]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A8]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(-\/(x))))))))
+    }
 
-    implicit val inja8: Inj[Cop, F[A9]] =
-      Inj.instance(x => \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))))
+    implicit val inja7: Inj[Cop, F[A8]] = Inj.instance(prisma7.reverseGet(_))
+    implicit val inja7Inverse: Inj[Option[F[A8]], Cop] = Inj.instance(prisma7.getOption(_))
 
-    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] =
-      Inj.instance(_ match {
+    implicit val prisma8: Prism[Cop, F[A9]] = new Prism[Cop, F[A9]] {
+      def getOption(c: Cop): Option[F[A9]] = c match {
         case \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x)))))))) => Some(x)
         case _                                         => None
-      })
+      }
+      def reverseGet(x: F[A9]): Cop = \/-(\/-(\/-(\/-(\/-(\/-(\/-(\/-(x))))))))
+    }
 
-    implicit def liftisoa0(implicit M: Monoid[Prod]): Prod <=> F[A1] =
-      IsoSet(_._1, x => M.zero.map1(_ => x))
+    implicit val inja8: Inj[Cop, F[A9]] = Inj.instance(prisma8.reverseGet(_))
+    implicit val inja8Inverse: Inj[Option[F[A9]], Cop] = Inj.instance(prisma8.getOption(_))
 
-    implicit def liftisoa1(implicit M: Monoid[Prod]): Prod <=> F[A2] =
-      IsoSet(_._2, x => M.zero.map2(_ => x))
+    implicit def lifta0(implicit M: Monoid[Prod]): Inj[Prod, F[A1]] = {
+      val (_, a0, a1, a2, a3, a4, a5, a6, a7) =
+        M.zero
+      Inj.instance((_, a0, a1, a2, a3, a4, a5, a6, a7))
+    }
 
-    implicit def liftisoa2(implicit M: Monoid[Prod]): Prod <=> F[A3] =
-      IsoSet(_._3, x => M.zero.map3(_ => x))
+    implicit val lifta0Inverse: Inj[F[A1], Prod] = Inj.instance(_._1)
 
-    implicit def liftisoa3(implicit M: Monoid[Prod]): Prod <=> F[A4] =
-      IsoSet(_._4, x => M.zero.map4(_ => x))
+    implicit def lifta1(implicit M: Monoid[Prod]): Inj[Prod, F[A2]] = {
+      val (a0, _, a1, a2, a3, a4, a5, a6, a7) =
+        M.zero
+      Inj.instance((a0, _, a1, a2, a3, a4, a5, a6, a7))
+    }
 
-    implicit def liftisoa4(implicit M: Monoid[Prod]): Prod <=> F[A5] =
-      IsoSet(_._5, x => M.zero.map5(_ => x))
+    implicit val lifta1Inverse: Inj[F[A2], Prod] = Inj.instance(_._2)
 
-    implicit def liftisoa5(implicit M: Monoid[Prod]): Prod <=> F[A6] =
-      IsoSet(_._6, x => M.zero.map6(_ => x))
+    implicit def lifta2(implicit M: Monoid[Prod]): Inj[Prod, F[A3]] = {
+      val (a0, a1, _, a2, a3, a4, a5, a6, a7) =
+        M.zero
+      Inj.instance((a0, a1, _, a2, a3, a4, a5, a6, a7))
+    }
 
-    implicit def liftisoa6(implicit M: Monoid[Prod]): Prod <=> F[A7] =
-      IsoSet(_._7, x => M.zero.map7(_ => x))
+    implicit val lifta2Inverse: Inj[F[A3], Prod] = Inj.instance(_._3)
 
-    implicit def liftisoa7(implicit M: Monoid[Prod]): Prod <=> F[A8] =
-      IsoSet(_._8, x => M.zero.map8(_ => x))
+    implicit def lifta3(implicit M: Monoid[Prod]): Inj[Prod, F[A4]] = {
+      val (a0, a1, a2, _, a3, a4, a5, a6, a7) =
+        M.zero
+      Inj.instance((a0, a1, a2, _, a3, a4, a5, a6, a7))
+    }
 
-    implicit def liftisoa8(implicit M: Monoid[Prod]): Prod <=> F[A9] =
-      IsoSet(_._9, x => M.zero.map9(_ => x))
+    implicit val lifta3Inverse: Inj[F[A4], Prod] = Inj.instance(_._4)
+
+    implicit def lifta4(implicit M: Monoid[Prod]): Inj[Prod, F[A5]] = {
+      val (a0, a1, a2, a3, _, a4, a5, a6, a7) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, _, a4, a5, a6, a7))
+    }
+
+    implicit val lifta4Inverse: Inj[F[A5], Prod] = Inj.instance(_._5)
+
+    implicit def lifta5(implicit M: Monoid[Prod]): Inj[Prod, F[A6]] = {
+      val (a0, a1, a2, a3, a4, _, a5, a6, a7) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, _, a5, a6, a7))
+    }
+
+    implicit val lifta5Inverse: Inj[F[A6], Prod] = Inj.instance(_._6)
+
+    implicit def lifta6(implicit M: Monoid[Prod]): Inj[Prod, F[A7]] = {
+      val (a0, a1, a2, a3, a4, a5, _, a6, a7) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, _, a6, a7))
+    }
+
+    implicit val lifta6Inverse: Inj[F[A7], Prod] = Inj.instance(_._7)
+
+    implicit def lifta7(implicit M: Monoid[Prod]): Inj[Prod, F[A8]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, _, a7) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, _, a7))
+    }
+
+    implicit val lifta7Inverse: Inj[F[A8], Prod] = Inj.instance(_._8)
+
+    implicit def lifta8(implicit M: Monoid[Prod]): Inj[Prod, F[A9]] = {
+      val (a0, a1, a2, a3, a4, a5, a6, a7, _) =
+        M.zero
+      Inj.instance((a0, a1, a2, a3, a4, a5, a6, a7, _))
+    }
+
+    implicit val lifta8Inverse: Inj[F[A9], Prod] = Inj.instance(_._9)
 
   }
 
@@ -165,8 +226,6 @@ trait AndXorK9[F[_], A1, A2, A3, A4, A5, A6, A7, A8, A9] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/core/src/main/scala/andxor/Inj.scala
+++ b/core/src/main/scala/andxor/Inj.scala
@@ -2,7 +2,6 @@ package andxor
 
 import scala.language.higherKinds
 import scalaz.{Applicative, Functor, Semigroup, \/}
-import scalaz.Isomorphism.<=>
 
 trait Inj[Cop, A] {
   def apply(a: A): Cop
@@ -17,8 +16,6 @@ object Inj {
   def instance[A, B](ab: A => B): Inj[B, A] = new Inj[B, A] {
     def apply(a: A): B = ab(a)
   }
-
-  def inject[B, A](a: A)(implicit inj: Inj[B, A]): B = inj(a)
 
   implicit def decidableInj[Cop]: Decidable[Aux[Cop]#Out] =
     new Decidable[Aux[Cop]#Out] {
@@ -43,11 +40,5 @@ object Inj {
           }
         }
     }
-
-  implicit def isoInj[A, B](implicit iso: A <=> B): Inj[B, A] = instance(iso.to)
-
-  implicit def apInjA[F[_], B, A](implicit F: Applicative[F], inj: Inj[B, A]): Inj[F[B], A] = instance(a => F.point(inj(a)))
-
-  implicit def fnInjA[F[_], B, A](implicit F: Functor[F], inj: Inj[B, A]): Inj[F[B], F[A]] = instance(F.map(_)(inj(_)))
 }
 

--- a/core/src/main/scala/andxor/Inj.scala
+++ b/core/src/main/scala/andxor/Inj.scala
@@ -18,7 +18,7 @@ object Inj {
     def apply(a: A): B = ab(a)
   }
 
-  def inject[Cop, A](a: A)(implicit inj: Inj[Cop, A]): Cop = inj(a)
+  def inject[B, A](a: A)(implicit inj: Inj[B, A]): B = inj(a)
 
   implicit def decidableInj[Cop]: Decidable[Aux[Cop]#Out] =
     new Decidable[Aux[Cop]#Out] {

--- a/core/src/main/scala/andxor/Inj.scala
+++ b/core/src/main/scala/andxor/Inj.scala
@@ -2,6 +2,7 @@ package andxor
 
 import scala.language.higherKinds
 import scalaz.{Applicative, Functor, Semigroup, \/}
+import scalaz.Isomorphism.<=>
 
 trait Inj[Cop, A] {
   def apply(a: A): Cop
@@ -43,12 +44,10 @@ object Inj {
         }
     }
 
-  implicit def apInjA[F[_], Cop, A](implicit F: Applicative[F], inj: Inj[Cop, A]): Inj[F[Cop], A] = new Inj[F[Cop], A] {
-    def apply(a: A): F[Cop] = F.point(inj(a))
-  }
+  implicit def isoInj[A, B](implicit iso: A <=> B): Inj[B, A] = instance(iso.to)
 
-  implicit def fnInjA[F[_], Cop, A](implicit F: Functor[F], inj: Inj[Cop, A]): Inj[F[Cop], F[A]] = new Inj[F[Cop], F[A]] {
-    def apply(a: F[A]): F[Cop] = F.map(a)(inj(_))
-  }
+  implicit def apInjA[F[_], B, A](implicit F: Applicative[F], inj: Inj[B, A]): Inj[F[B], A] = instance(a => F.point(inj(a)))
+
+  implicit def fnInjA[F[_], B, A](implicit F: Functor[F], inj: Inj[B, A]): Inj[F[B], F[A]] = instance(F.map(_)(inj(_)))
 }
 

--- a/core/src/main/scala/andxor/Inj.scala
+++ b/core/src/main/scala/andxor/Inj.scala
@@ -39,5 +39,13 @@ object Inj {
           }
         }
     }
+
+  implicit def injACops[Cop, A](implicit inj: Inj[Cop, A]): Inj[List[Cop], A] = new Inj[List[Cop], A] {
+    def apply(a: A): List[Cop] = List(inj(a))
+  }
+
+  implicit def injListACops[Cop, A](implicit inj: Inj[Cop, A]): Inj[List[Cop], List[A]] = new Inj[List[Cop], List[A]] {
+    def apply(a: List[A]): List[Cop] = a.map(inj(_))
+  }
 }
 

--- a/core/src/main/scala/andxor/Prism.scala
+++ b/core/src/main/scala/andxor/Prism.scala
@@ -1,0 +1,6 @@
+package andxor
+
+trait Prism[A, B] {
+  def getOption(a: A): Option[B]
+  def reverseGet(b: B): A
+}

--- a/generate/src/main/scala/andxor/Syntax.scala
+++ b/generate/src/main/scala/andxor/Syntax.scala
@@ -41,5 +41,8 @@ object syntax {
 
   implicit class ZipperOps[A](z: Zipper[A]) {
     def toList: List[A] = z.toStream.toList
+
+    def djVal(v: String): String =
+      z.lefts.foldLeft(Some(z.rights).filter(_.nonEmpty).map(_ => s"-\\/($v)").getOrElse(v))((a, _) => s"\\/-($a)")
   }
 }

--- a/generate/src/main/scala/andxor/Syntax.scala
+++ b/generate/src/main/scala/andxor/Syntax.scala
@@ -1,6 +1,7 @@
 package andxor
 
 import scalaz.syntax.comonad._
+import scalaz.syntax.std.boolean._
 import scalaz.Zipper
 
 object syntax {
@@ -44,5 +45,14 @@ object syntax {
 
     def djVal(v: String): String =
       z.lefts.foldLeft(Some(z.rights).filter(_.nonEmpty).map(_ => s"-\\/($v)").getOrElse(v))((a, _) => s"\\/-($a)")
+
+    def djFold(v: String, fail: String => String, succ: String => String): String = {
+      val init = z.rights.nonEmpty.fold((x: String) => s"$x.fold(l => ${succ("l")}, r => ${fail("r")})", fail)
+      val folds = 0.to(z.lefts.length - 1).foldLeft(init) { (acc, i) =>
+        val (l, r) = (s"a$i", s"a${i + 1}")
+        (x: String) => s"$x.fold($l => ${fail(l)}, $r => ${acc(r)})"
+      }
+      folds(v)
+    }
   }
 }

--- a/generate/src/main/twirl/template/AndXorN.scala.txt
+++ b/generate/src/main/twirl/template/AndXorN.scala.txt
@@ -1,9 +1,12 @@
 @import andxor.syntax._
 
 @(tpes: List[String])
+
+import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 import scalaz.syntax.either._
 

--- a/generate/src/main/twirl/template/AndXorN.scala.txt
+++ b/generate/src/main/twirl/template/AndXorN.scala.txt
@@ -66,6 +66,8 @@ trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
+  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
+
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(
     implicit O: Ordering[AndXorK@{tpes.length}[Id, @{tpes.prod}]#Cop], M: Monoid[C],

--- a/generate/src/main/twirl/template/AndXorN.scala.txt
+++ b/generate/src/main/twirl/template/AndXorN.scala.txt
@@ -4,6 +4,7 @@
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
+import scalaz.std.list._
 import scalaz.syntax.either._
 
 trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
@@ -60,6 +61,10 @@ trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
       @{tpes.zipper(SequenceC(_)).mkString("")}
     }
   } *@
+
+  def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
+
+  def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/generate/src/main/twirl/template/AndXorN.scala.txt
+++ b/generate/src/main/twirl/template/AndXorN.scala.txt
@@ -2,11 +2,9 @@
 
 @(tpes: List[String])
 
-import andxor.MapN.syntax._
 import scala.language.higherKinds
 import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
-import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
 
 trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
@@ -67,8 +65,6 @@ trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
   def extractC[B](c: Cop)(implicit inj: Inj[Option[B], Cop]): Option[B] = inj(c)
 
   def extractP[B](p: Prod)(implicit inj: Inj[B, Prod]): B = inj(p)
-
-  def toListP(p: Prod): List[Cop] = combine[Inj.Aux[List[Cop]]#Out].divide.apply(p)
 
   def foldMap[G[_], C](p: AndXor[G]#Prod)(
     map: AndXor[Id]#Cop => C)(

--- a/generate/src/main/twirl/template/AndXorN.scala.txt
+++ b/generate/src/main/twirl/template/AndXorN.scala.txt
@@ -8,7 +8,6 @@ import scalaz.{Apply, Foldable, Functor, PlusEmpty, Monoid, \/, -\/, \/-, ~>}
 import scalaz.Id.Id
 import scalaz.Isomorphism.{<=>, IsoSet}
 import scalaz.std.list._
-import scalaz.syntax.either._
 
 trait AndXorK@{tpes.length}[F[_], @{tpes.prod}] extends AndXor {
   type Prod = @{tpes.prodK("F")}

--- a/generate/src/main/twirl/template/Inj.scala.txt
+++ b/generate/src/main/twirl/template/Inj.scala.txt
@@ -3,11 +3,13 @@
 
 @(z: Zipper[String])
 
-  implicit val inja@{z.index}: Inj[Cop, F[@{z.focus}]] =
-    Inj.instance(x => @z.djVal("x"))
-
-  implicit val inja@{z.index}Inverse: Inj[Option[F[@{z.focus}]], Cop] =
-    Inj.instance(_ match {
+  implicit val prisma@{z.index}: Prism[Cop, F[@{z.focus}]] = new Prism[Cop, F[@{z.focus}]] {
+    def getOption(c: Cop): Option[F[@{z.focus}]] = c match {
       case @z.djVal("x") => Some(x)
       case _ => None
-    })
+    }
+    def reverseGet(x: F[@{z.focus}]): Cop = @z.djVal("x")
+  }
+
+  implicit val inja@{z.index}: Inj[Cop, F[@{z.focus}]] = Inj.instance(prisma@{z.index}.reverseGet(_))
+  implicit val inja@{z.index}Inverse: Inj[Option[F[@{z.focus}]], Cop] = Inj.instance(prisma@{z.index}.getOption(_))

--- a/generate/src/main/twirl/template/Inj.scala.txt
+++ b/generate/src/main/twirl/template/Inj.scala.txt
@@ -4,14 +4,10 @@
 @(z: Zipper[String])
 
   implicit val inja@{z.index}: Inj[Cop, F[@{z.focus}]] =
-    Inj.instance(_@{
-      Some(z.rights.toList).filter(_.nonEmpty)
-        .map(rt => s""".left[${rt.djK("F")}]""").getOrElse("")}@{
-     z.lefts.toList.map(rt => s""".right[F[${rt}]]""")
-      .mkString("")})
+    Inj.instance(x => @z.djVal("x"))
 
   implicit val inja@{z.index}Inverse: Inj[Option[F[@{z.focus}]], Cop] =
     Inj.instance(_ match {
-      case @{z.lefts.foldLeft(Some(z.rights).filter(_.nonEmpty).map(_ => "-\\/(x)").getOrElse("x"))((acc, _) => s"\\/-($acc)")} => Some(x)
+      case @z.djVal("x") => Some(x)
       case _ => None
     })

--- a/generate/src/main/twirl/template/Inj.scala.txt
+++ b/generate/src/main/twirl/template/Inj.scala.txt
@@ -9,3 +9,9 @@
         .map(rt => s""".left[${rt.djK("F")}]""").getOrElse("")}@{
      z.lefts.toList.map(rt => s""".right[F[${rt}]]""")
       .mkString("")})
+
+  implicit val inja@{z.index}Inverse: Inj[Option[F[@{z.focus}]], Cop] =
+    Inj.instance(_ match {
+      case @{z.lefts.foldLeft(Some(z.rights).filter(_.nonEmpty).map(_ => "-\\/(x)").getOrElse("x"))((acc, _) => s"\\/-($acc)")} => Some(x)
+      case _ => None
+    })

--- a/generate/src/main/twirl/template/Lift.scala.txt
+++ b/generate/src/main/twirl/template/Lift.scala.txt
@@ -11,3 +11,5 @@
       ((f.lefts.toList.paramList("a") :+ "_") ++
         f.rights.toList.paramList("a", f.lefts.length)).mkString(", ")}))
   }
+
+  implicit val lifta@{f.index}Inverse: Inj[F[@{f.focus}], Prod] = Inj.instance(_._@{f.index + 1})

--- a/generate/src/main/twirl/template/Lift.scala.txt
+++ b/generate/src/main/twirl/template/Lift.scala.txt
@@ -2,14 +2,5 @@
 @import scalaz.Zipper
 
 @(f: Zipper[String])
-  implicit def lifta@{f.index}(implicit M: Monoid[Prod]): Inj[Prod, F[@{f.focus}]] = {
-    val (@{
-  ((f.lefts.toList.paramList("a") :+ "_") ++
-    f.rights.toList.paramList("a", f.lefts.length)).mkString(", ")}) =
-        M.zero
-    Inj.instance((@{
-      ((f.lefts.toList.paramList("a") :+ "_") ++
-        f.rights.toList.paramList("a", f.lefts.length)).mkString(", ")}))
-  }
-
-  implicit val lifta@{f.index}Inverse: Inj[F[@{f.focus}], Prod] = Inj.instance(_._@{f.index + 1})
+  implicit def liftisoa@{f.index}(implicit M: Monoid[Prod]): Prod <=> F[@{f.focus}] =
+    IsoSet(_._@{f.index + 1}, x => M.zero.map@{f.index + 1}(_ => x))

--- a/generate/src/main/twirl/template/Lift.scala.txt
+++ b/generate/src/main/twirl/template/Lift.scala.txt
@@ -2,5 +2,14 @@
 @import scalaz.Zipper
 
 @(f: Zipper[String])
-  implicit def liftisoa@{f.index}(implicit M: Monoid[Prod]): Prod <=> F[@{f.focus}] =
-    IsoSet(_._@{f.index + 1}, x => M.zero.map@{f.index + 1}(_ => x))
+  implicit def lifta@{f.index}(implicit M: Monoid[Prod]): Inj[Prod, F[@{f.focus}]] = {
+    val (@{
+  ((f.lefts.toList.paramList("a") :+ "_") ++
+    f.rights.toList.paramList("a", f.lefts.length)).mkString(", ")}) =
+        M.zero
+    Inj.instance((@{
+      ((f.lefts.toList.paramList("a") :+ "_") ++
+        f.rights.toList.paramList("a", f.lefts.length)).mkString(", ")}))
+  }
+
+  implicit val lifta@{f.index}Inverse: Inj[F[@{f.focus}], Prod] = Inj.instance(_._@{f.index + 1})

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -54,4 +54,7 @@ SISO.extractC[Option[String]](SISO.inj(Option("foo")))
 SISO.extractC[Option[Int]](SISO.inj(Option("foo")))
 SISO.extractP[Option[String]](SISO.lift(Option("foo")))
 SISO.extractP[Option[Int]](SISO.lift(Option(1)))
+
+// convert a Prod to a List[Cop]
+SISL.toListP((List("foo"), List(1), List(List("bar"))))
 ```

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -48,4 +48,10 @@ SISO.transformP(o2l)(os)
 import andxor.MapN.syntax._
 SISO.inj(Option(2)).map1(_.map(_.length)).map2(_.map(_.toString ++ "!"))
 SISO.lift(Option("foo")).map2(_.map(_.toString ++ "!")).map1(_.map(_.length))
+
+// extract specific type from Cop or Prod
+SISO.extractC[Option[String]](SISO.inj(Option("foo")))
+SISO.extractC[Option[Int]](SISO.inj(Option("foo")))
+SISO.extractP[Option[String]](SISO.lift(Option("foo")))
+SISO.extractP[Option[Int]](SISO.lift(Option(1)))
 ```

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -12,7 +12,7 @@ With an instance of Decidable, Alt, Divide, or Apply for a given typeclass,
 provides an instance for the corresponding Coproduct, or Product respectively.
 
 ```tut
-import andxor.{AndXorF3, AndXor3, Decidable, Inj}
+import andxor.{AndXorF3, AndXor3, Decidable}
 import scalaz.std.anyVal._
 import scalaz.std.list._
 import scalaz.std.option._
@@ -53,15 +53,4 @@ SISO.extractC[Option[String]](SISO.inj(Option("foo")))
 SISO.extractC[Option[Int]](SISO.inj(Option("foo")))
 SISO.extractP[Option[String]](SISO.lift(Option("foo")))
 SISO.extractP[Option[Int]](SISO.lift(Option(1)))
-
-// convert a Prod to a List[Cop]
-SISL.toListP((List("foo"), List(1), List(List("bar"))))
-
-// inject into applicative
-Inj.inject[List[SISO.Cop], Option[String]](Some("foo"))
-Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
-
-// inject F[A] into F[B] given a Functor[F]
-Inj.inject[List[SISO.Cop], List[Option[String]]](List(Some("foo")))
-Inj.inject[Option[SISO.Cop], Option[Option[Int]]](None)
 ```

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -60,4 +60,8 @@ SISL.toListP((List("foo"), List(1), List(List("bar"))))
 // inject into applicative
 Inj.inject[List[SISO.Cop], Option[String]](Some("foo"))
 Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
+
+// inject F[A] into F[B] given a Functor[F]
+Inj.inject[List[SISO.Cop], List[Option[String]]](List(Some("foo")))
+Inj.inject[Option[SISO.Cop], Option[Option[Int]]](None)
 ```

--- a/src/main/tut/README.md
+++ b/src/main/tut/README.md
@@ -12,8 +12,7 @@ With an instance of Decidable, Alt, Divide, or Apply for a given typeclass,
 provides an instance for the corresponding Coproduct, or Product respectively.
 
 ```tut
-import andxor.{AndXorF3, AndXor3}
-import andxor.Decidable
+import andxor.{AndXorF3, AndXor3, Decidable, Inj}
 import scalaz.std.anyVal._
 import scalaz.std.list._
 import scalaz.std.option._
@@ -57,4 +56,8 @@ SISO.extractP[Option[Int]](SISO.lift(Option(1)))
 
 // convert a Prod to a List[Cop]
 SISL.toListP((List("foo"), List(1), List(List("bar"))))
+
+// inject into applicative
+Inj.inject[List[SISO.Cop], Option[String]](Some("foo"))
+Inj.inject[Option[SISO.Cop], Option[Int]](Some(1))
 ```


### PR DESCRIPTION
- Update scala version to 2.12.7
- Update scalaz version to 7.2.26
- Add `extractP` function to extract a given type from a product using the inject instances
- Add implicit `inja{n}Inverse` to define `Inj[Option[F[A{N}]], Cop]`
- Add `extractC` function to extract an optional type from a coproduct using the inverse inject instance
- Simplify some of the templated code 